### PR TITLE
Reboot-time deletion + full COM surface cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository purpose
+
+Two PowerShell scripts that pair together as a Microsoft Intune **Proactive Remediation** (Platform Scripts): `detect.ps1` decides whether action is needed and `remediate.ps1` does the cleanup. They run as SYSTEM, log to the Intune Management Extension log folder, and target Lenovo AI Now bloatware on Lenovo OEM devices.
+
+There is no build, test, or package step — these are deployed by uploading the two `.ps1` files to Intune. Validate changes by running them locally on a Windows test box (or a VM with the target software installed) under an elevated PowerShell session. There is no test harness to run from this repo.
+
+## How the two scripts contract together
+
+`detect.ps1` exit code drives whether Intune invokes `remediate.ps1`:
+
+- **exit 1** → remediation needed. Trigger conditions (any of): matching uninstall registry entry, known executable found under an install root, running process matching a known name, matching service, OR file count under any install root exceeds `$fileThreshold` (currently 5).
+- **exit 0** → no action. Note: residual files *below* the threshold still produce exit 0 — this is intentional, to avoid re-triggering remediation cycles after a 3010 reboot-pending success.
+
+If you change one script's detection/match patterns, change the other's to match. The two scripts maintain parallel lists of: registry roots, install paths, executable names, service-name regex/wildcards.
+
+## Remediation pipeline (order matters)
+
+`Invoke-LenovoAiNowRemediation` in `remediate.ps1` runs steps in this order, and the order is load-bearing:
+
+1. Discover install paths from uninstall registry entries (`Get-LenovoAiNowEntries`), union with `$defaultInstallPaths`.
+2. Early exit (return 0) if no entries AND no install paths exist — but still scrub user-profile leftovers and Start Menu shortcuts before returning.
+3. Stop services under those paths, then stop processes (twice — once by path, once by executable name) so handles are released before file deletion.
+4. `Remove-LenovoAIServices` deletes service registrations via `sc.exe delete` (must come *after* stops).
+5. `Unregister-LenovoAIShellExtensions` removes CLSID entries whose `InprocServer32` points at a Lenovo AI Now DLL — these hold Explorer file locks if left in place.
+6. `Remove-UserData`, `Remove-StartMenuShortcuts`, `Remove-ScheduledTasks`.
+7. `Remove-Residuals` deletes remaining install directories and a hardcoded list of registry keys.
+8. **Re-run** the stop-services/stop-processes pass — some components respawn during cleanup.
+9. Verify residuals; if any remain, escalate (see below) and compute the return code.
+
+Keep this order when refactoring. Skipping the second stop pass or running shell-extension cleanup after the directory delete will cause locked-file failures.
+
+## Escalation ladder for stubborn directories
+
+`Remove-DirectoryWithRetry` in `remediate.ps1` is the central deletion utility, with progressive escalation across attempts:
+
+1. **Attempt 1**: `takeown /r /d y` + `icacls /grant Administrators:F /t`, then `Remove-Item -Recurse -Force`.
+2. **Attempt 2 (on failure)**: stop services/processes under the path again, then **robocopy with `/MIR` from an empty temp directory** to forcibly empty the target, then remove the now-empty dir. Robocopy reliably deletes files that `Remove-Item` chokes on (long paths, unusual ACLs).
+3. **Attempt 2 fallback**: stop `explorer.exe` and `dllhost.exe` for ~3 seconds to release shell-extension DLL handles, retry deletion, then restart Explorer.
+4. **Final attempt (on max retries)**: if ≤5 files remain, rename each to `*.tobedeleted` and queue them via `Add-PendingFileDelete` (writes to `HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations`) so Windows deletes them on next boot. This drives the **3010** exit code.
+
+When debugging "won't delete" issues, work down this ladder rather than adding more `Remove-Item` retries at the top.
+
+## Exit code translation (Intune compatibility)
+
+`remediate.ps1` distinguishes between its **internal** result and the **Intune-reported** exit code:
+
+| Internal | Intune (`$intuneExitCode`) | Meaning |
+|----------|---------------------------|---------|
+| 0        | 0                         | Clean removal |
+| 3010     | 0                         | Success, reboot pending — Intune sees this as success so it doesn't re-trigger before reboot |
+| 1603     | 1                         | Partial failure (residuals remain) |
+| 1        | 1                         | Unhandled exception |
+
+Both values are logged. **Don't collapse this into a single exit value** — Intune retries on non-zero, and treating 3010 as failure causes loops on devices that need a reboot.
+
+## Per-user cleanup (HKEY_USERS via SID)
+
+`Remove-UserData` enumerates `C:\Users\*` (skipping system profiles via `Get-UserProfileDirectories`), and for each user resolves the SID through three fallbacks in `Resolve-UserProfileSid`:
+
+1. `Win32_UserProfile` CIM class by `LocalPath`.
+2. `HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList` by `ProfileImagePath`.
+3. `NTAccount.Translate(SecurityIdentifier)`.
+
+It then cleans `Registry::HKEY_USERS\<sid>\...` keys directly — this is necessary because the user's `HKCU` hive is only mounted while they're logged in, so SYSTEM-context scripts must address per-user data through the `HKEY_USERS` hive by SID. Reuse `Resolve-UserProfileSid` rather than rolling new SID-resolution logic.
+
+## Logging
+
+All `Write-Log` calls in `remediate.ps1` go to `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\Lenovo_AI_Now_Remediate.log`. `detect.ps1` uses `Write-Host` only — Intune captures stdout for detection scripts, so logging there is implicit. When adding diagnostic output to `remediate.ps1`, prefer `Write-Log` with an explicit level (`INFO`/`WARNING`/`ERROR`/`DEBUG`).

--- a/README.md
+++ b/README.md
@@ -1,105 +1,129 @@
 Lenovo AI Now Removal Script
 ============================
 
-This repository contains PowerShell scripts to detect and remove "Lenovo AI Now" a vendor-installed application often considered bloatware on Lenovo devices. These scripts are designed primarily for use with Microsoft Intune Remediation scripts, but can be adapted to other deployment tools.
+PowerShell scripts to detect and remove **Lenovo AI Now** — an OEM-installed application bundled on recent Lenovo devices that many organisations treat as bloatware. Designed for **Microsoft Intune Proactive Remediation**, though the scripts can be adapted to other SYSTEM-context deployment tools.
 
-Contents
---------
+> **Note**: This is a substantially rewritten fork of the upstream
+> [`nullifyac/Lenovo-AI-Now-Script-Uninstall`](https://github.com/nullifyac/Lenovo-AI-Now-Script-Uninstall).
+> See "What this fork changes" below for the reasoning.
 
-- **detect.ps1**  
-  A detection script that checks whether Lenovo AI Now is currently installed.  
-  - Exits **1** if Lenovo AI Now is found in uninstall registry entries, common install paths, or running services/processes.  
-  - Exits **0** if Lenovo AI Now is not detected.
+Why removal is non-trivial
+--------------------------
 
-- **remediate.ps1**  
-  The remediation (removal) script that:
-  1. Checks if Lenovo AI Now is present (if not, exits successfully).
-  2. If present, performs comprehensive cleanup: stops services/processes, removes program files, cleans registry entries, removes shortcuts, unregisters shell extensions, and removes scheduled tasks.
-  3. **Cleanup Logic:**  
-     - Leverages multiple functions for stubborn files: ownership changes (takeown/icacls), robocopy mirror deletion, Explorer downtime windows, and scheduling deletions for reboot when necessary.
-     - Performs final verification and returns appropriate exit codes.
-  4. **Exit Codes:**  
-     - **0**: Complete success, all components removed.  
-     - **3010**: Success, reboot recommended (locked files scheduled for deletion).  
-     - **1603**: Partial failure, some residual components remain.  
-     - **1**: Unhandled error during remediation.
+Lenovo AI Now installs two shell-extension DLLs (`AINppShell.dll` and `OverlayIcon.dll`) that are loaded by virtually every shell-using GUI process on the machine — File Explorer, Office apps, browsers, anything that opens a common file dialog. The DLLs cannot be deleted in-session because the OS marks them as in-use across many processes. Killing Explorer doesn't help: Windows auto-restarts it within ~1 second (`AutoRestartShell`), and the DLLs are still held by all the non-Explorer consumers. The reliable cleanup path is to schedule the locked files via `PendingFileRenameOperations` and let SMSS delete them at the next boot, before any shell process starts.
 
-How It Works
+The scripts also handle the **MSIX/AppX** side (`AINowContextWIN11`, the Win11 context-menu extension), the **full COM registration surface** (3 CLSIDs + AppID + TypeLib + 2 ProgIDs + 10 shellex handler subkeys + `ShellIconOverlayIdentifiers` entry + `Shell Extensions\Approved` value), the **per-user repository stubs** that Microsoft's `Remove-AppxPackage` leaves behind, and **multi-user machines** (enumerates HKEY_USERS by SID).
+
+Two-phase model
+---------------
+
+| Phase | When it runs | What it does | Exit code |
+|---|---|---|---|
+| **Phase A** | First Intune Proactive Remediation cycle | Cleans services, processes, AppX package, AppX repository stubs, shell extension surface, user data, shortcuts, scheduled tasks. Removes the install directory if possible; queues locked files via PFRO if not. Writes a sentinel so detect doesn't loop. | **3010** (Intune reports 0 / success) |
+| **Phase B** | After the user's organic reboot, next detect cycle | Verifies install directory is gone, removes any AppX repository stubs that resurfaced, confirms clean state. | **0** |
+
+Between Phase A and the user's reboot, `detect.ps1` reads the sentinel and short-circuits to **exit 0**, so Intune won't keep firing remediate (which would bloat `PendingFileRenameOperations`).
+
+Exit code semantics
+-------------------
+
+`remediate.ps1` distinguishes its internal result from the Intune-reported code:
+
+| Internal | Intune | Meaning |
+|---|---|---|
+| 0 | 0 | Clean removal, no reboot needed |
+| 3010 | 0 | Phase A complete, reboot pending. Reported as success so Intune doesn't re-trigger before the user reboots |
+| 1603 | 1 | Partial failure — residuals remain and PFRO queue failed |
+| 1 | 1 | Unhandled exception |
+
+Requirements
 ------------
 
-1. **Detection**  
-   - In Intune, run **detect.ps1** as the detection script.  
-   - Checks uninstall registry keys (32-bit and 64-bit), common Lenovo install paths, and running services/processes matching Lenovo AI Now patterns.
-   - If it exits **1**, Lenovo AI Now is present; if it exits **0**, Lenovo AI Now is not present.
+- **Run script in 64-bit PowerShell** must be **Yes** in the Intune PR settings.
+  - Reason: Intune defaults Proactive Remediation scripts to 32-bit PowerShell, which silently redirects `HKLM:\SOFTWARE\Classes\CLSID` reads to the `Wow6432Node` hive. All of Lenovo AI Now's CLSIDs and uninstall registry entry live in the **64-bit** hive, so a 32-bit script reads an empty view and cleans nothing.
+  - Both scripts include a self-relaunch guard that re-invokes them under `C:\Windows\SysNative\WindowsPowerShell\v1.0\powershell.exe` if Intune started them 32-bit. The toggle is still recommended (saves one process spawn per cycle).
+- **Targeting**: assign the PR script to Lenovo devices only. A device filter on `Manufacturer -eq "LENOVO"` is reasonable.
+- **Schedule**: daily detection is fine; the default 8-hour cadence is fine too. The sentinel prevents detection-loop bloat between Phase A and reboot.
 
-2. **Remediation / Removal**  
-   - When Lenovo AI Now is present, run **remediate.ps1**:
-     1. Enumerates uninstall entries and install paths.
-     2. Stops related services and processes.
-     3. Attempts vendor uninstaller if non-interactive command available (prefers manual cleanup).
-     4. Removes program files, user data, and shortcuts using escalated removal techniques.
-     5. Cleans registry keys, scheduled tasks, and shell extension registrations.
-     6. Re-checks for residuals and reports final status.
+Deployment
+----------
 
-Deployment Scenarios
---------------------
-
-**Intune (Platform Scripts - Recommended)**
-
-- Upload **detect.ps1** as the Detection Script.  
-- Upload **remediate.ps1** as the Remediation Script.  
-- Both run under SYSTEM context by default.
-- If detect.ps1 exits 1, Intune triggers remediate.ps1.
-
-**Win32 App (Untested)**
-
-- Can be packaged as a Win32 app for pre-provisioned devices.
-- **Warning**: Win32 deployment is untested test thoroughly in a pilot environment first.
+1. In the Intune admin centre, go to **Devices → Scripts and remediations → Platform scripts (Proactive Remediations)**.
+2. Create a new script package:
+   - **Detection script**: `detect.ps1`
+   - **Remediation script**: `remediate.ps1`
+   - **Run script as logged-on user**: No (run as SYSTEM)
+   - **Enforce script signature check**: No
+   - **Run script in 64-bit PowerShell**: **Yes** (important — see Requirements)
+3. Assign to a Lenovo-only device group.
 
 Files
 -----
 
-| File           | Description                                                                                           |
-|----------------|-------------------------------------------------------------------------------------------------------|
-| detect.ps1     | Checks registry, install paths, and running services/processes. Exits 1 if found, 0 if not.        |
-| remediate.ps1  | Full removal script that performs comprehensive cleanup with escalated removal techniques.           |
-| README.md      | This documentation.                                                                                   |
+| File | Description |
+|---|---|
+| `detect.ps1` | Detection: registry, install paths, processes, services, AppX packages, AppX repository stubs, sentinel suppression. Exits 1 on any find. |
+| `remediate.ps1` | Full removal: two-phase model, COM surface cleanup, MSIX removal, PFRO queue for locked files, sentinel write. |
+| `tools/diagnose_clsid_walk.ps1` | Optional read-only diagnostic that times the CLSID hive walk via PowerShell cmdlets vs the .NET registry API. Useful when investigating registry-walk performance on a specific device. |
+| `README.md` | This file. |
+| `CLAUDE.md` | Design contract for the repo (escalation ladder, exit code mapping, per-user cleanup approach). |
 
-Logs & Troubleshooting
+Logs & troubleshooting
 ----------------------
 
-**Log Location:**  
-`C:\ProgramData\Microsoft\IntuneManagementExtension\Logs`
+**Log path**: `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\Lenovo_AI_Now_Remediate.log`
 
-**Log Files:**
+(The detect script writes to Intune's standard PR stdout capture, not a separate log file. Use the Intune console or `AgentExecutor.log` for detection output.)
 
-- `Lenovo_AI_Now_Detect.log`  
-- `Lenovo_AI_Now_Remediate.log` 
+**Common scenarios:**
 
-**Common Scenarios:**
+- **Exit 3010 (Phase A complete, reboot pending)**: expected on first run for any device with the install dir still present. User reboots, PFRO clears the install dir at next boot, next detect cycle exits 0.
+- **Exit 1603 (partial failure)**: residuals remain AND the PFRO queue write failed. Check the log for `Failed to write PendingFileRenameOperations`. Rare; usually indicates registry write protection (e.g., very aggressive ASR/EDR policy).
+- **Exit 1 (unhandled exception)**: check the log for `REMEDIATION FAILED: Unhandled exception` and the position message that follows.
+- **Detect keeps triggering remediate with no observed cleanup**: the device may not be receiving the latest script version. Verify with `Get-ChildItem 'C:\Windows\IMECache\HealthScripts\<guid>_*' -Directory` and check the highest-numbered cache version is current.
 
-1. **Exit Code 3010 (Reboot Recommended)**  
-   - Some files were locked and scheduled for deletion on reboot.
-   - Reboot the device to complete cleanup.
+**MDE Advanced Hunting queries** (useful for monitoring fleet rollout):
 
-2. **Exit Code 1603 (Partial Failure)**  
-   - Check remediation log for WARNING/ERROR entries about residual files or registry keys.
-   - May require manual cleanup or additional remediation attempts.
+```kql
+// Devices in Phase A (sentinel set, waiting for reboot)
+DeviceRegistryEvents
+| where Timestamp > ago(14d)
+| where RegistryKey has @"SOFTWARE\LenovoAINowRemediation"
+| where RegistryValueName == "PhaseAComplete"
+| where ActionType == "RegistryValueSet"
+| summarize PhaseAAt = max(Timestamp) by DeviceName, DeviceId
+| extend HoursSincePhaseA = datetime_diff('hour', now(), PhaseAAt)
+```
 
-3. **Stubborn Components**  
-   - The script uses multiple techniques including Explorer downtime and file locking workarounds.
-   - For persistent issues, check the log for specific files/registry keys that couldn't be removed.
+```kql
+// Cleanup progress: should trend to zero as devices reboot
+DeviceImageLoadEvents
+| where Timestamp > ago(7d)
+| where FileName in~ ("AINppShell.dll", "OverlayIcon.dll")
+| summarize Loads = count(), Devices = dcount(DeviceId) by FileName
+```
 
-Notes & Tips
-------------
+What this fork changes
+----------------------
 
-1. **SYSTEM Context**  
-   - Scripts are designed to run under SYSTEM context (standard for Intune platform scripts).
+The upstream version tries to delete files in-session and uses an Explorer-kill window plus a "schedule ≤5 locked files for reboot delete" fallback. In production this loses against `AutoRestartShell` and against the 17+ non-Explorer processes that also hold the DLLs, so most devices end up with 270 residual files and no PFRO queue. Notable changes in this fork:
 
-2. **Manual vs. Vendor Cleanup**  
-   - Scripts perform manual cleanup rather than relying on interactive vendor uninstallers.
+- **Pivot to PFRO + reboot as the primary path** for the install directory. Drop the Explorer-kill block and the ≤5-file PFRO gate.
+- **Self-relaunch under 64-bit PowerShell** so the script sees the correct registry hive.
+- **Full mapping of the COM registration surface**: hardcodes the 3 confirmed CLSIDs + AppID + TypeLib + 2 ProgIDs + 10 shellex handler subkeys; also walks both 64-bit and `Wow6432Node` CLSID hives dynamically via the .NET registry API (`Microsoft.Win32.Registry`), which is ~200× faster than `Get-ChildItem` on registry paths.
+- **MSIX/AppX handling**: `Remove-AppxPackage -AllUsers` for `AINowContextWIN11`, plus `Remove-AppxProvisionedPackage -Online`, plus explicit cleanup of the orphaned per-user repository stubs at `HKU\<sid>\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\Repository\Packages` and the HKLM `AppxAllUserStore` mirrors. Microsoft's removal leaves these behind.
+- **Service disable-before-stop** sequence (`sc config start= disabled` → `Stop-Service` → `WaitForStatus('Stopped', 30s)` → `sc delete`) to prevent auto-restart races.
+- **Wildcard match for the uninstall DisplayName** — the upstream regex `^Lenovo AI Now\b` silently didn't match the actual `Lenovo AI Now 1.3` entry on observed devices.
+- **`-LiteralPath` for registry paths containing literal `*`** — the upstream used `-Path`, which expanded `*` as a wildcard across every HKCR subkey and could hang for minutes.
+- **Sentinel + suppression** in detect to prevent retrigger between Phase A and reboot.
+- **Removed dead code** (`Invoke-Uninstaller`, `Invoke-MsiUninstall`) and the robocopy fallback (which can deadlock against kernel-locked DLLs).
 
-3. **Testing**  
-   - Test in a pilot environment before broad deployment.
-   - Monitor logs for any unexpected behavior or residual components.
+Validated on two real Lenovo devices: one starting from full fresh-install state (exercised the PFRO + reboot path), one in mid-cleanup state (exercised direct deletion after natural reboot). Both reached exit 0.
 
+Caveats
+-------
+
+- The scripts do not handle Lenovo Vantage / Commercial Vantage re-pushing AI Now after removal. If your fleet has a Vantage policy that re-installs the app, a separate Vantage policy change is needed.
+- "Lenovo AI Solution", "Lenovo AI Meeting Manager", and other Lenovo AI-family apps are **out of scope**. The scripts match specifically on `*Lenovo AI Now*` and the known CLSIDs.
+- Win32 app deployment is untested. Test thoroughly in a pilot environment first.
+- Tested against Lenovo AI Now version 1.3 only. Future versions with different CLSIDs would still be caught by the dynamic walk (matched by DLL filename + parent path containing `\Lenovo\Lenovo AI\`), but new DLL filenames would need the script's `$lenovoAIDllFileNames` list extended.

--- a/detect.ps1
+++ b/detect.ps1
@@ -1,16 +1,73 @@
 [CmdletBinding()]
 param()
 
+# Re-launch under native 64-bit PowerShell if Intune started us in 32-bit
+# (the default for Proactive Remediation scripts). Without this, registry
+# reads against HKLM:\SOFTWARE are silently WOW64-redirected to
+# HKLM:\SOFTWARE\Wow6432Node, which on Lenovo AI Now devices misses both
+# the uninstall key and the CLSID registrations -- they all live in the
+# 64-bit hive.
+if ($env:PROCESSOR_ARCHITECTURE -eq 'x86' -and (Test-Path "$env:WINDIR\SysNative\WindowsPowerShell\v1.0\powershell.exe")) {
+    & "$env:WINDIR\SysNative\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File $PSCommandPath @args
+    exit $LASTEXITCODE
+}
+
 $ErrorActionPreference = "SilentlyContinue"
 $fileThreshold = 5
 
 Write-Host "=== Lenovo AI Now Detection Script ==="
+
+# Sentinel suppression: if remediate.ps1 already queued cleanup via
+# PendingFileRenameOperations, suppress retrigger until reboot completes
+# so we don't loop and bloat the PFRO registry value.
+$sentinelKey = 'HKLM:\SOFTWARE\LenovoAINowRemediation'
+$sentinelValueName = 'PhaseAComplete'
+$sentinelStaleAfterDays = 7
+
+$suppressForReboot = $false
+if (Test-Path -Path $sentinelKey) {
+    try {
+        $sentinelStamp = Get-ItemPropertyValue -Path $sentinelKey -Name $sentinelValueName -ErrorAction Stop
+        $sentinelTime = [datetime]::Parse(
+            $sentinelStamp,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::AssumeUniversal)
+        $ageDays = ((Get-Date).ToUniversalTime() - $sentinelTime.ToUniversalTime()).TotalDays
+        if ($ageDays -le $sentinelStaleAfterDays) {
+            $pfroEntries = @()
+            try {
+                $pfroEntries = @(Get-ItemPropertyValue `
+                    -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' `
+                    -Name 'PendingFileRenameOperations' -ErrorAction Stop)
+            } catch {
+                $pfroEntries = @()
+            }
+            if ($pfroEntries | Where-Object { $_ -match '(?i)lenovo' }) {
+                $suppressForReboot = $true
+                Write-Host "Phase A complete (queued $sentinelStamp, $([math]::Round($ageDays,1)) days ago). Pending reboot to finish cleanup."
+            } else {
+                Write-Host "Sentinel present but PFRO no longer references Lenovo; treating as cleared."
+            }
+        } else {
+            Write-Host "Sentinel is stale (>$sentinelStaleAfterDays days). Ignoring."
+        }
+    } catch {
+        Write-Host "Sentinel value unreadable: $($_.Exception.Message)"
+    }
+}
+
+if ($suppressForReboot) {
+    Write-Host "Suppressing remediation trigger; cleanup is queued for next boot."
+    Write-Host "Exit Code 0"
+    exit 0
+}
 
 $foundRegistry = $false
 $totalFiles = 0
 $binaryMatches = @()
 $processMatches = @()
 $serviceMatches = @()
+$appxMatches = @()
 
 $targetNamePattern = '*Lenovo AI Now*'
 $registryRoots = @(
@@ -44,23 +101,30 @@ $installRoots = @(
     "C:\ProgramData\Lenovo\Lenovo AI Now"
 )
 
+# Actual on-disk filenames per the Lenovo AI Now 1.3 install manifest.
+# "AINow" is one word; an earlier list used "Lenovo AI Now X.exe" with a
+# space and matched nothing.
 $candidateExecutables = @(
-    'LenovoAINow.exe',
-    'Lenovo AI Now.exe',
-    'Lenovo AI Now Helper.exe',
-    'Lenovo AI Now Service.exe',
-    'Lenovo AI Now Utility.exe',
-    'Lenovo AI Now Mini.exe',
-    'Lenovo AI Now OOBE.exe',
-    'Lenovo AI Now SafetyChecker.exe',
-    'Lenovo AI Now Launcher.exe'
+    'Lenovo AINow.exe',
+    'Lenovo AINow Helper.exe',
+    'Lenovo AINow Launcher.exe',
+    'Lenovo AINow Mini.exe',
+    'Lenovo AINow OOBE.exe',
+    'Lenovo AINow SafetyChecker.exe',
+    'Lenovo AINow Service.exe',
+    'Lenovo AINow Utility.exe',
+    'Lenovo AINow Uninstall.exe',
+    'AINow.TostNotification.exe'
 )
 
 Write-Host "Checking installation directories..."
 foreach ($root in $installRoots) {
     if (Test-Path $root) {
-        $files = Get-ChildItem -Path $root -Recurse -File -ErrorAction SilentlyContinue
-        $fileCount = $files.Count
+        # Exclude *.tobedeleted (queued by Phase A) so they don't keep
+        # retriggering remediation between phases.
+        $files = Get-ChildItem -Path $root -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -notlike '*.tobedeleted' }
+        $fileCount = @($files).Count
         Write-Host "Directory found: $root - File count: $fileCount"
         $totalFiles += $fileCount
 
@@ -77,23 +141,13 @@ foreach ($root in $installRoots) {
 }
 
 Write-Host "Checking for Lenovo AI Now processes..."
+$processNamesLower = $candidateExecutables |
+    ForEach-Object { ([IO.Path]::GetFileNameWithoutExtension($_)).ToLowerInvariant() }
 try {
-    $running = Get-Process -ErrorAction SilentlyContinue
-    foreach ($proc in $running) {
+    foreach ($proc in Get-Process -ErrorAction SilentlyContinue) {
         $name = $proc.Name
         if (-not $name) { continue }
-        $nameLower = $name.ToLowerInvariant()
-        if ($nameLower -in @(
-            'lenovoainow',
-            'lenovo ainow',
-            'lenovo ainow helper',
-            'lenovo ainow service',
-            'lenovo ainow utility',
-            'lenovo ainow mini',
-            'lenovo ainow oobe',
-            'lenovo ainow safetychecker',
-            'lenovo ainow launcher'
-        )) {
+        if ($processNamesLower -contains $name.ToLowerInvariant()) {
             Write-Host "Detected running process: $name (PID $($proc.Id))"
             $processMatches += $name
         }
@@ -110,8 +164,8 @@ try {
         $serviceName = $svc.Name
         $pathName = $svc.PathName
 
-        $nameMatch = ($displayName -and ($displayName -like 'Lenovo AI Now*')) -or
-                     ($serviceName -and ($serviceName -like 'LenovoAINow*'))
+        $nameMatch = ($displayName -and ($displayName -like '*Lenovo AI*')) -or
+                     ($serviceName -and ($serviceName -like 'LenovoAI*'))
 
         $pathMatch = $false
         if (-not $nameMatch -and $pathName) {
@@ -141,13 +195,75 @@ try {
     Write-Host "Could not enumerate services: $($_.Exception.Message)"
 }
 
-Write-Host "Total Lenovo AI Now file count: $totalFiles"
+Write-Host "Checking for AppX/MSIX packages..."
+try {
+    $installed = @(Get-AppxPackage -AllUsers -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -like '*AINow*' -or $_.Name -like '*LenovoAI*' })
+    foreach ($pkg in $installed) {
+        Write-Host "Detected AppX package: $($pkg.Name) $($pkg.Version)"
+        $appxMatches += $pkg.PackageFullName
+    }
+    try {
+        $provisioned = @(Get-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue |
+            Where-Object { $_.PackageName -like '*AINow*' -or $_.DisplayName -like '*Lenovo*AI*' })
+        foreach ($pkg in $provisioned) {
+            Write-Host "Detected provisioned AppX package: $($pkg.PackageName)"
+            $appxMatches += $pkg.PackageName
+        }
+    } catch {
+        # Get-AppxProvisionedPackage can throw on PS that lacks the DISM module
+    }
+} catch {
+    Write-Host "Could not enumerate AppX packages: $($_.Exception.Message)"
+}
+
+# Orphaned AppX repository stubs. Get-AppxPackage doesn't enumerate them,
+# but they live on in HKU\<sid>\...\AppModel\Repository\Packages and in
+# HKLM:\...\Appx\AppxAllUserStore\* after a partial Remove-AppxPackage.
+Write-Host "Checking for orphaned AppX repository stubs..."
+$appxStubMatches = @()
+try {
+    $userKeys = Get-ChildItem 'Registry::HKEY_USERS' -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.PSChildName -match '^S-1-\d+(-\d+)+$' -and
+            $_.PSChildName -notmatch '_Classes$'
+        }
+    foreach ($userKey in $userKeys) {
+        $repoPath = "$($userKey.PSPath)\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\Repository\Packages"
+        if (-not (Test-Path -LiteralPath $repoPath)) { continue }
+        $stubs = Get-ChildItem -LiteralPath $repoPath -ErrorAction SilentlyContinue |
+            Where-Object { $_.PSChildName -like '*AINow*' -or $_.PSChildName -like '*LenovoAI*' }
+        foreach ($s in $stubs) {
+            Write-Host "Detected orphaned AppX repository stub: $($s.PSChildName) (SID: $($userKey.PSChildName))"
+            $appxStubMatches += $s.PSChildName
+        }
+    }
+} catch {
+    Write-Host "Could not enumerate HKU AppX repository: $($_.Exception.Message)"
+}
+foreach ($root in @(
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\Applications',
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\Deprovisioned',
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\InboxApplications'
+)) {
+    if (-not (Test-Path -LiteralPath $root)) { continue }
+    $stubs = Get-ChildItem -LiteralPath $root -ErrorAction SilentlyContinue |
+        Where-Object { $_.PSChildName -like '*AINow*' -or $_.PSChildName -like '*LenovoAI*' }
+    foreach ($s in $stubs) {
+        Write-Host "Detected HKLM AppX stub: $($s.PSChildName) (root: $root)"
+        $appxStubMatches += $s.PSChildName
+    }
+}
+
+Write-Host "Total Lenovo AI Now file count (excluding *.tobedeleted): $totalFiles"
 
 $shouldRemediate = $false
 if ($foundRegistry) { Write-Host "Registry traces detected."; $shouldRemediate = $true }
 if ($binaryMatches.Count -gt 0) { Write-Host "Lenovo AI Now binaries detected."; $shouldRemediate = $true }
 if ($processMatches.Count -gt 0) { Write-Host "Lenovo AI Now processes are running."; $shouldRemediate = $true }
 if ($serviceMatches.Count -gt 0) { Write-Host "Lenovo AI Now services detected."; $shouldRemediate = $true }
+if ($appxMatches.Count -gt 0) { Write-Host "Lenovo AI Now AppX packages detected."; $shouldRemediate = $true }
+if ($appxStubMatches.Count -gt 0) { Write-Host "Orphaned AppX repository stubs detected."; $shouldRemediate = $true }
 if ($totalFiles -gt $fileThreshold) { Write-Host "File count exceeds threshold ($fileThreshold)."; $shouldRemediate = $true }
 
 if ($shouldRemediate) {

--- a/remediate.ps1
+++ b/remediate.ps1
@@ -1,4 +1,31 @@
-# Remediate Lenovo AI Now by performing a silent uninstall when possible.
+# Remediate Lenovo AI Now.
+#
+# Two-phase model:
+#   Phase A -- clean what can be cleaned in-session (services, processes,
+#             user data, shortcuts, uninstall reg entry, shell-extension
+#             registrations, AppX/MSIX package). Queue any locked install-
+#             dir files for boot-time deletion via PendingFileRenameOperations.
+#             Write a sentinel so detect.ps1 can suppress retrigger until
+#             the user reboots. Exit 3010, Intune treats as success.
+#   Phase B -- after user reboots, SMSS processes PFRO, install dir is gone,
+#             detect re-fires clean, exit 0.
+#
+# Why reboot-time deletion: AINppShell.dll (property handler) and
+# OverlayIcon.dll (icon overlay handler) are loaded by virtually every
+# shell-using GUI app on the machine (Word, Edge, Outlook, Chrome,
+# any app that opens a file dialog). In-session deletion is unwinnable;
+# SMSS processes PFRO before any of those processes exist on the next boot.
+
+# Re-launch under native 64-bit PowerShell if Intune started us in 32-bit
+# (the default for Proactive Remediation scripts). 32-bit PS reads of
+# HKLM:\SOFTWARE\... are silently WOW64-redirected to Wow6432Node, where
+# the Lenovo AI Now CLSIDs and uninstall key are NOT present -- so the
+# script runs blind and deletes nothing.
+if ($env:PROCESSOR_ARCHITECTURE -eq 'x86' -and (Test-Path "$env:WINDIR\SysNative\WindowsPowerShell\v1.0\powershell.exe")) {
+    & "$env:WINDIR\SysNative\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File $PSCommandPath @args
+    exit $LASTEXITCODE
+}
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
@@ -7,12 +34,24 @@ $logFolder = "C:\ProgramData\Microsoft\IntuneManagementExtension\Logs"
 if (-not (Test-Path $logFolder)) { New-Item -ItemType Directory -Path $logFolder | Out-Null }
 $logFile = Join-Path $logFolder "Lenovo_AI_Now_Remediate.log"
 
+# Rotate log if larger than 5 MB; many remediation cycles can otherwise
+# fill the IME log folder.
+try {
+    if ((Test-Path $logFile) -and ((Get-Item $logFile).Length -gt 5MB)) {
+        $rotated = "$logFile.old"
+        if (Test-Path $rotated) { Remove-Item $rotated -Force -ErrorAction SilentlyContinue }
+        Move-Item $logFile $rotated -Force -ErrorAction SilentlyContinue
+    }
+} catch {
+    # rotation is best-effort
+}
+
 function Write-Log {
     param(
         [Parameter(Position=0)]
         [string]$Message,
         [Parameter(Position=1)]
-        [ValidateSet("INFO","WARNING","ERROR","DEBUG")] 
+        [ValidateSet("INFO","WARNING","ERROR","DEBUG")]
         [string]$Level = "INFO"
     )
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
@@ -23,7 +62,11 @@ function Write-Log {
 
 Write-Log "=== Starting Lenovo AI Now Remediation Script ==="
 
-$targetNamePattern = '^Lenovo AI Now\b'
+# Wildcard match (same as detect.ps1). Earlier regex `^Lenovo AI Now\b`
+# failed to match the actual uninstall DisplayName on real devices, which
+# is why the uninstall key survived prior remediation runs.
+$targetDisplayNamePattern = '*Lenovo AI Now*'
+
 $uninstallRoots = @(
     'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
     'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
@@ -33,16 +76,65 @@ $defaultInstallPaths = @(
     'C:\Program Files (x86)\Lenovo\Lenovo AI Now',
     'C:\ProgramData\Lenovo\Lenovo AI Now'
 )
+
+# Confirmed via direct registry inspection on Lenovo AI Now 1.3.
+$knownLenovoAIClsids = @(
+    '{281E645C-1F68-4276-80F6-8476CED89BB1}',  # AINppShell handler (Win11 MSIX-bound + legacy)
+    '{B872E6A0-3D43-48B9-BF55-6952BE5B297A}',  # AINppShell handler (Win10 legacy, "LenovoAINowShell")
+    '{4B48C68B-80D6-40FB-B4D1-63C19130EC75}'   # OverlayIcon handler
+)
+
+# COM satellite keys created by the OverlayIcon registration.
+$knownLenovoAISatelliteKeys = @(
+    'HKLM:\SOFTWARE\Classes\AppID\{5D1C76DE-B933-40AC-B588-6B46EA0A45C9}',
+    'HKLM:\SOFTWARE\Classes\TypeLib\{8EE1DABC-E488-4AB8-8184-817AA4456D51}',
+    'HKLM:\SOFTWARE\Classes\LenovoAINowOverlayIcon.MyLenovoAINowOverlayIcon.1',
+    'HKLM:\SOFTWARE\Classes\LenovoAINowOverlayIcon.MyLenovoAINowOverlayIcon'
+)
+
+# shellex handler registrations under each file-type root. Subkey name
+# is literally "Lenovo AI Now" (with spaces).
+$knownLenovoAIShellexKeys = @(
+    'HKLM:\SOFTWARE\Classes\*\shellex\ContextMenuHandlers\Lenovo AI Now',
+    'HKLM:\SOFTWARE\Classes\*\shellex\DragDropHandlers\Lenovo AI Now',
+    'HKLM:\SOFTWARE\Classes\Directory\shellex\ContextMenuHandlers\Lenovo AI Now',
+    'HKLM:\SOFTWARE\Classes\Directory\shellex\DragDropHandlers\Lenovo AI Now',
+    'HKLM:\SOFTWARE\Classes\Drive\shellex\ContextMenuHandlers\Lenovo AI Now',
+    'HKLM:\SOFTWARE\Classes\Drive\shellex\DragDropHandlers\Lenovo AI Now',
+    'HKLM:\SOFTWARE\Classes\Folder\shellex\ContextMenuHandlers\Lenovo AI Now',
+    'HKLM:\SOFTWARE\Classes\Folder\shellex\DragDropHandlers\Lenovo AI Now',
+    'HKLM:\SOFTWARE\Classes\lnkfile\shellex\ContextMenuHandlers\Lenovo AI Now',
+    'HKLM:\SOFTWARE\Classes\lnkfile\shellex\DragDropHandlers\Lenovo AI Now'
+)
+
+# DLL filenames that identify a Lenovo AI Now COM in-proc server, used by
+# the registry-walk fallback. Path must also contain "\Lenovo\" to avoid
+# colliding with unrelated DLLs of the same name from other vendors.
+$lenovoAIDllFileNames = @('AINppShell.dll', 'OverlayIcon.dll')
+
+# Sentinel written after Phase A queues PFRO, read by detect.ps1.
+$sentinelKey = 'HKLM:\SOFTWARE\LenovoAINowRemediation'
+$sentinelValueName = 'PhaseAComplete'
+
+# Process executable names (lowercased, with .exe) for path-less kill pass.
+# Match Win32_Process.Name which includes the extension.
+$processExecutables = @(
+    'lenovo ainow.exe',
+    'lenovo ainow helper.exe',
+    'lenovo ainow launcher.exe',
+    'lenovo ainow mini.exe',
+    'lenovo ainow oobe.exe',
+    'lenovo ainow safetychecker.exe',
+    'lenovo ainow service.exe',
+    'lenovo ainow utility.exe',
+    'lenovo ainow uninstall.exe',
+    'ainow.tostnotification.exe'
+)
+
 function Get-UninstallEntries {
-    param(
-        [string[]]$Roots
-    )
-
+    param([string[]]$Roots)
     foreach ($root in $Roots) {
-        if (-not (Test-Path -Path $root)) {
-            continue
-        }
-
+        if (-not (Test-Path -Path $root)) { continue }
         foreach ($child in Get-ChildItem -Path $root -ErrorAction SilentlyContinue) {
             try {
                 $item = Get-ItemProperty -Path $child.PSPath -ErrorAction Stop
@@ -59,7 +151,7 @@ function Get-LenovoAiNowEntries {
     Get-UninstallEntries -Roots $uninstallRoots |
         Where-Object {
             $_.PSObject.Properties['DisplayName'] -and
-            $_.DisplayName -match $targetNamePattern
+            $_.DisplayName -like $targetDisplayNamePattern
         }
 }
 
@@ -71,15 +163,15 @@ function Stop-ProcessesUnderPaths {
         [int]$DelaySeconds = 2
     )
 
-    $normalizedPaths = $Paths |
+    $normalizedPaths = @($Paths |
         Where-Object { $_ } |
         ForEach-Object { $_.TrimEnd('\') } |
-        Where-Object { $_ }
+        Where-Object { $_ })
 
-    $normalizedExecutables = $ExecutableNames |
+    $normalizedExecutables = @($ExecutableNames |
         Where-Object { $_ } |
         ForEach-Object { $_.Trim().ToLowerInvariant() } |
-        Select-Object -Unique
+        Select-Object -Unique)
 
     for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
         try {
@@ -91,9 +183,7 @@ function Stop-ProcessesUnderPaths {
 
         $targets = @()
         foreach ($process in $processes) {
-            if (-not $process.Name) {
-                continue
-            }
+            if (-not $process.Name) { continue }
             $match = $false
             $processNameLower = $process.Name.ToLowerInvariant()
 
@@ -113,15 +203,11 @@ function Stop-ProcessesUnderPaths {
                 }
             }
 
-            if ($match) {
-                $targets += $process
-            }
+            if ($match) { $targets += $process }
         }
 
         if (-not $targets) {
-            if ($attempt -eq 1) {
-                Write-Log 'No Lenovo AI Now processes detected.'
-            }
+            if ($attempt -eq 1) { Write-Log 'No Lenovo AI Now processes detected.' }
             break
         }
 
@@ -144,19 +230,50 @@ function Stop-ProcessesUnderPaths {
     }
 }
 
-function Stop-ServicesUnderPaths {
-    param(
-        [string[]]$Paths
-    )
+function Disable-AndStopService {
+    # Disable the service so SCM can't restart it, then stop, wait for
+    # Stopped state, and delete. Prevents the auto-restart race that left
+    # AINppShell.dll locked in prior runs.
+    param([Parameter(Mandatory)][string]$Name)
 
-    $normalized = $Paths |
+    try {
+        Start-Process -FilePath 'sc.exe' -ArgumentList "config `"$Name`" start= disabled" -WindowStyle Hidden -Wait -ErrorAction SilentlyContinue | Out-Null
+    } catch {
+        Write-Log "sc config disabled failed for $Name : $($_.Exception.Message)" "DEBUG"
+    }
+
+    try {
+        Stop-Service -Name $Name -Force -ErrorAction Stop
+    } catch {
+        Write-Log "Stop-Service $Name failed: $($_.Exception.Message)" "DEBUG"
+    }
+
+    try {
+        $svc = Get-Service -Name $Name -ErrorAction Stop
+        $svc.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(30))
+    } catch {
+        Write-Log "WaitForStatus Stopped on $Name failed: $($_.Exception.Message)" "DEBUG"
+    }
+
+    try {
+        $del = Start-Process -FilePath 'sc.exe' -ArgumentList "delete `"$Name`"" -WindowStyle Hidden -Wait -PassThru -ErrorAction Stop
+        if ($del.ExitCode -ne 0) {
+            Write-Log "sc delete $Name returned exit code $($del.ExitCode)"
+        } else {
+            Write-Log "Service $Name deleted."
+        }
+    } catch {
+        Write-Log "sc delete $Name failed: $($_.Exception.Message)"
+    }
+}
+
+function Stop-ServicesUnderPaths {
+    param([string[]]$Paths)
+    $normalized = @($Paths |
         Where-Object { $_ } |
         ForEach-Object { $_.TrimEnd('\') } |
-        Where-Object { $_ }
-
-    if (-not $normalized) {
-        return
-    }
+        Where-Object { $_ })
+    if (-not $normalized) { return }
 
     try {
         $services = Get-CimInstance Win32_Service -ErrorAction Stop
@@ -167,21 +284,15 @@ function Stop-ServicesUnderPaths {
 
     foreach ($service in $services) {
         $pathName = $service.PathName
-        if (-not $pathName) {
-            continue
-        }
+        if (-not $pathName) { continue }
 
         $executable = $null
         if ($pathName -match '^\s*"(?<path>[^"]+)"') {
             $executable = $matches.path
         } else {
-            $segments = $pathName -split '\s+', 2
-            $executable = $segments[0]
+            $executable = ($pathName -split '\s+', 2)[0]
         }
-
-        if (-not $executable) {
-            continue
-        }
+        if (-not $executable) { continue }
 
         $matchesInstallPath = $false
         foreach ($path in $normalized) {
@@ -190,189 +301,186 @@ function Stop-ServicesUnderPaths {
                 break
             }
         }
+        if (-not $matchesInstallPath) { continue }
 
-        if (-not $matchesInstallPath) {
-            continue
+        if ($service.State -eq 'Running') {
+            Write-Log "Stopping service $($service.Name) with path $executable"
         }
-
-        if ($service.State -ne 'Running') {
-            continue
-        }
-
-        try {
-            Write-Log "Stopping service $($service.Name) (PID $($service.ProcessId)) with path $executable"
-            Stop-Service -Name $service.Name -Force -ErrorAction Stop
-        } catch {
-            Write-Log "Failed to stop service $($service.Name): $($_.Exception.Message)"
-        }
+        Disable-AndStopService -Name $service.Name
     }
 }
 
 function Remove-DirectoryWithRetry {
+    # Attempts in-session deletion only. Any files that can't be removed
+    # are handled by the caller via Add-PendingFileDeleteBatch for boot-time
+    # cleanup. No Explorer-kill or AutoRestartShell race -- that approach
+    # cannot succeed when shell-extension DLLs are loaded into 18+
+    # processes across the system.
     param(
         [Parameter(Mandatory = $true)]
         [string]$Path,
-        [int]$MaxAttempts = 3,
-        [int]$DelaySeconds = 5
+        [int]$MaxAttempts = 2,
+        [int]$DelaySeconds = 3
     )
 
-    if (-not (Test-Path -Path $Path)) {
-        return $true
-    }
+    if (-not (Test-Path -Path $Path)) { return $true }
 
     for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
         try {
             Write-Log "Removing directory $Path (attempt $attempt of $MaxAttempts)"
-            
-            # First try to take ownership and grant full permissions
             try {
                 & takeown /f "$Path" /r /d y 2>&1 | Out-Null
                 & icacls "$Path" /grant Administrators:F /t 2>&1 | Out-Null
             } catch {
-                Write-Log "Failed to take ownership or set permissions: $($_.Exception.Message)"
+                Write-Log "takeown/icacls failed on $Path : $($_.Exception.Message)" "DEBUG"
             }
-            
-            # Try normal removal first
             Remove-Item -Path $Path -Recurse -Force -ErrorAction Stop
             return $true
         } catch {
-            Write-Log "Failed to remove directory $($Path): $($_.Exception.Message)"
-            Write-Log "DEBUG: About to check if attempt $attempt < $MaxAttempts"
+            Write-Log "Failed to remove $Path : $($_.Exception.Message)"
             if ($attempt -lt $MaxAttempts) {
-                Write-Log "DEBUG: Entered attempt $attempt retry logic"
+                # Kill anything new under the path before retrying takeown +
+                # Remove-Item. Don't try robocopy as a fallback -- it can
+                # hang indefinitely against kernel-locked DLLs (e.g. loaded
+                # shell extensions), exceeding Intune's PR timeout. Locked
+                # files are PFRO's job, not robocopy's.
                 Stop-ServicesUnderPaths -Paths @($Path)
-                Stop-ProcessesUnderPaths -Paths @($Path)
-                
-                # Try using robocopy to delete stubborn files
-                try {
-                    Write-Log "DEBUG: Starting robocopy attempt"
-                    $tempEmpty = Join-Path $env:TEMP "EmptyForRobocopy"
-                    if (-not (Test-Path $tempEmpty)) {
-                        New-Item -Path $tempEmpty -ItemType Directory -Force | Out-Null
-                    }
-                    
-                    Write-Log "Using robocopy to forcefully remove directory contents"
-                    $robocopyOutput = & robocopy "$tempEmpty" "$Path" /MIR /R:0 /W:0 2>&1
-                    Write-Log "DEBUG: Robocopy exit code: $LASTEXITCODE"
-                    if ($robocopyOutput) {
-                        foreach ($line in ($robocopyOutput | Select-Object -First 5)) {
-                            Write-Log "DEBUG: Robocopy output: $line"
-                        }
-                    }
-                    
-                    # Clean up temp directory
-                    Remove-Item -Path $tempEmpty -Force -ErrorAction SilentlyContinue
-                    
-                    # Check if directory still exists
-                    if (-not (Test-Path $Path)) {
-                        Write-Log "DEBUG: Robocopy successfully removed directory"
-                        return $true
-                    }
-                    
-                    # Try removing the now-empty directory
-                    Write-Log "DEBUG: Attempting to remove directory after robocopy"
-                    Remove-Item -Path $Path -Force -ErrorAction Stop
-                    Write-Log "DEBUG: Directory removal after robocopy succeeded"
-                    return $true
-                } catch {
-                    Write-Log "Robocopy method failed with exception: $($_.Exception.Message)"
-                }
-                
-                # Always try the Explorer downtime approach on the second attempt
-                if ($attempt -eq 2) {
-                    Write-Log "DEBUG: Attempt $attempt reached, about to stop Explorer"
-                    try {
-                        Write-Log "Stopping Explorer for 5 seconds to release shell extension DLLs"
-                        Stop-Process -Name explorer -Force -ErrorAction SilentlyContinue
-                        Stop-Process -Name dllhost -Force -ErrorAction SilentlyContinue
-                        Start-Sleep -Seconds 3  # Wait longer for DLLs to fully unload
-                        
-                        Write-Log "DEBUG: Explorer stopped, attempting deletion"
-                        # Try to delete the directory during the explorer-free window
-                        try {
-                            Remove-Item -Path $Path -Recurse -Force -ErrorAction Stop
-                            Write-Log "Successfully removed directory during Explorer downtime"
-                            Start-Process explorer -ErrorAction SilentlyContinue
-                            return $true
-                        } catch {
-                            Write-Log "Directory removal during Explorer downtime failed: $($_.Exception.Message)"
-                        }
-                        
-                        # Always restart Explorer
-                        Write-Log "DEBUG: Restarting Explorer"
-                        Start-Process explorer -ErrorAction SilentlyContinue
-                        Start-Sleep -Seconds 2  # Let Explorer fully restart
-                    } catch {
-                        Write-Log "Failed to stop/start Explorer: $($_.Exception.Message)"
-                        # Make sure Explorer is running
-                        try {
-                            Start-Process explorer -ErrorAction SilentlyContinue
-                        } catch {}
-                    }
-                }
-                
+                Stop-ProcessesUnderPaths -Paths @($Path) -ExecutableNames $processExecutables
                 Start-Sleep -Seconds $DelaySeconds
-            } else {
-                # Final attempt - schedule locked files for deletion on reboot
-                try {
-                    Write-Log "Scheduling remaining locked files for deletion on reboot"
-                    $lockedFiles = Get-ChildItem -Path $Path -Recurse -Force -ErrorAction SilentlyContinue
-                    
-                    if ($lockedFiles.Count -le 5) {  # Only a few files left
-                        foreach ($file in $lockedFiles) {
-                            if (-not $file.PSIsContainer) {
-                                try {
-                                    # Try to rename first
-                                    $newName = $file.FullName + ".tobedeleted"
-                                    Move-Item -Path $file.FullName -Destination $newName -ErrorAction SilentlyContinue
-                                    
-                                    # Schedule for deletion on reboot
-                                    $filePath = if (Test-Path $newName) { $newName } else { $file.FullName }
-                                    Add-PendingFileDelete -FilePath $filePath
-                                } catch {
-                                    Write-Log "Could not schedule $($file.FullName) for deletion: $($_.Exception.Message)"
-                                }
-                            }
-                        }
-                        Write-Log "Scheduled locked files for deletion on next reboot"
-                        return $true  # Consider this successful
-                    }
-                } catch {
-                    Write-Log "Failed to schedule files for deletion: $($_.Exception.Message)"
-                }
-                
-                return $false
             }
         }
     }
+    return $false
 }
 
-function Add-PendingFileDelete {
+function Add-PendingFileDeleteBatch {
+    # Atomic, deduped, single-write batch of PendingFileRenameOperations
+    # entries. SMSS processes PFRO during early boot before any shell
+    # process is loaded, which is the only reliable way to delete files
+    # held open by shell-extension DLLs across many processes.
+    #
+    # The MULTI_SZ format is paired strings: source, destination. Empty
+    # destination means delete. Source must be in NT path form (\??\<path>).
+    # Directories must come AFTER their contents (bottom-up); SMSS won't
+    # delete a non-empty directory.
     param(
-        [string]$FilePath
+        [Parameter(Mandatory)][string[]]$FilePaths,
+        [Parameter(Mandatory)][string[]]$DirectoryPaths   # already ordered bottom-up
     )
-    
+
+    $regPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager'
+    $regName = 'PendingFileRenameOperations'
+
+    # Read existing entries; preserve them so we don't clobber Windows
+    # Update / driver-install pending operations from other components.
+    $existing = @()
     try {
-        $regPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager"
-        $regName = "PendingFileRenameOperations"
-        
-        # Get current pending operations
-        $currentOps = @()
-        try {
-            $currentOps = (Get-ItemProperty -Path $regPath -Name $regName -ErrorAction SilentlyContinue).$regName
-            if (-not $currentOps) { $currentOps = @() }
-        } catch {
-            # Property doesn't exist, create it
+        $raw = Get-ItemProperty -Path $regPath -Name $regName -ErrorAction Stop
+        if ($raw.PSObject.Properties[$regName]) {
+            $existing = @($raw.$regName)
         }
-        
-        # Add new operation (rename to empty string = delete)
-        $newOps = $currentOps + @("\??\$FilePath", "")
-        
-        # Set the registry value
-        Set-ItemProperty -Path $regPath -Name $regName -Value $newOps -Type MultiString -Force
-        Write-Log "Added $FilePath to pending file operations for deletion on reboot"
     } catch {
-        Write-Log "Failed to add pending file operation: $($_.Exception.Message)"
+        $existing = @()
+    }
+
+    # Build a hashset of source paths already queued so we don't duplicate.
+    $existingSources = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
+    for ($i = 0; $i -lt $existing.Count; $i += 2) {
+        if ($existing[$i]) { [void]$existingSources.Add($existing[$i]) }
+    }
+
+    $newEntries = New-Object System.Collections.Generic.List[string]
+    $added = 0
+
+    foreach ($file in $FilePaths) {
+        if (-not $file) { continue }
+        $src = "\??\$file"
+        if ($existingSources.Contains($src)) { continue }
+        $newEntries.Add($src)
+        $newEntries.Add('')
+        [void]$existingSources.Add($src)
+        $added++
+    }
+
+    foreach ($dir in $DirectoryPaths) {
+        if (-not $dir) { continue }
+        $src = "\??\$dir"
+        if ($existingSources.Contains($src)) { continue }
+        $newEntries.Add($src)
+        $newEntries.Add('')
+        [void]$existingSources.Add($src)
+        $added++
+    }
+
+    if ($added -eq 0) {
+        Write-Log "PendingFileRenameOperations: no new entries to queue."
+        return 0
+    }
+
+    $combined = @($existing) + $newEntries.ToArray()
+    try {
+        Set-ItemProperty -Path $regPath -Name $regName -Value $combined -Type MultiString -Force -ErrorAction Stop
+        Write-Log "Queued $added items in PendingFileRenameOperations (total: $($combined.Count / 2) entries)."
+        return $added
+    } catch {
+        Write-Log "Failed to write PendingFileRenameOperations: $($_.Exception.Message)" "ERROR"
+        return 0
+    }
+}
+
+function Get-PendingDeleteCandidates {
+    # Walk a directory bottom-up, returning files and dirs in delete order
+    # (files first, then leaf dirs, then parents, root last).
+    param([Parameter(Mandatory)][string]$Path)
+
+    if (-not (Test-Path -Path $Path)) {
+        return @{ Files = @(); Directories = @() }
+    }
+
+    $files = @()
+    $dirs = @()
+    try {
+        # SortByLength descending => deepest paths first. Files appear deeper
+        # than the dirs containing them; this gives a usable bottom-up order
+        # without recursive traversal.
+        $allItems = Get-ChildItem -Path $Path -Recurse -Force -ErrorAction SilentlyContinue |
+            Sort-Object -Property { $_.FullName.Length } -Descending
+        foreach ($item in $allItems) {
+            if ($item.PSIsContainer) {
+                $dirs += $item.FullName
+            } else {
+                $files += $item.FullName
+            }
+        }
+    } catch {
+        Write-Log "Enumerating $Path for PFRO failed: $($_.Exception.Message)"
+    }
+    $dirs += $Path
+
+    return @{ Files = $files; Directories = $dirs }
+}
+
+function Set-PhaseACompleteSentinel {
+    try {
+        if (-not (Test-Path -Path $sentinelKey)) {
+            New-Item -Path $sentinelKey -Force -ErrorAction Stop | Out-Null
+        }
+        $stamp = (Get-Date).ToUniversalTime().ToString('o')
+        Set-ItemProperty -Path $sentinelKey -Name $sentinelValueName -Value $stamp -Type String -Force
+        Write-Log "Phase A sentinel written: $stamp"
+    } catch {
+        Write-Log "Failed to write Phase A sentinel: $($_.Exception.Message)" "WARNING"
+    }
+}
+
+function Clear-PhaseACompleteSentinel {
+    try {
+        if (Test-Path -Path $sentinelKey) {
+            Remove-Item -Path $sentinelKey -Recurse -Force -ErrorAction Stop
+            Write-Log "Phase A sentinel cleared."
+        }
+    } catch {
+        Write-Log "Failed to clear Phase A sentinel: $($_.Exception.Message)" "DEBUG"
     }
 }
 
@@ -388,21 +496,15 @@ function Get-UserProfileDirectories {
 
 function Resolve-UserProfileSid {
     param(
-        [Parameter(Mandatory = $true)]
-        [string]$LocalPath,
-        [Parameter(Mandatory = $true)]
-        [string]$ProfileName
+        [Parameter(Mandatory = $true)][string]$LocalPath,
+        [Parameter(Mandatory = $true)][string]$ProfileName
     )
 
     try {
         $cimProfiles = Get-CimInstance -ClassName Win32_UserProfile -ErrorAction SilentlyContinue |
             Where-Object { $_.LocalPath -eq $LocalPath }
-        if ($cimProfiles) {
-            foreach ($cimProfile in $cimProfiles) {
-                if ($cimProfile.SID) {
-                    return $cimProfile.SID
-                }
-            }
+        foreach ($cimProfile in @($cimProfiles)) {
+            if ($cimProfile.SID) { return $cimProfile.SID }
         }
     } catch {
         Write-Log "Resolve-UserProfileSid: CIM lookup failed for $LocalPath : $($_.Exception.Message)" "DEBUG"
@@ -411,46 +513,37 @@ function Resolve-UserProfileSid {
     try {
         $profileListKey = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList'
         if (Test-Path -Path $profileListKey) {
-            $profileEntries = Get-ChildItem -Path $profileListKey -ErrorAction SilentlyContinue
-            foreach ($entry in $profileEntries) {
+            foreach ($entry in Get-ChildItem -Path $profileListKey -ErrorAction SilentlyContinue) {
                 try {
                     $profileData = Get-ItemProperty -Path $entry.PSPath -ErrorAction Stop
-                    if ($profileData.ProfileImagePath -and ($profileData.ProfileImagePath -ieq $LocalPath)) {
+                    if ($profileData.PSObject.Properties['ProfileImagePath'] -and
+                        $profileData.ProfileImagePath -and
+                        ($profileData.ProfileImagePath -ieq $LocalPath)) {
                         return $entry.PSChildName
                     }
-                } catch {
-                    # Ignore individual profile entry failures
-                }
+                } catch { }
             }
         }
     } catch {
-        Write-Log "Resolve-UserProfileSid: Registry lookup failed for $LocalPath : $($_.Exception.Message)" "DEBUG"
+        Write-Log "Resolve-UserProfileSid: registry lookup failed for $LocalPath : $($_.Exception.Message)" "DEBUG"
     }
 
     try {
         $ntAccount = New-Object System.Security.Principal.NTAccount($ProfileName)
         $sid = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier]).Value
-        if ($sid) {
-            return $sid
-        }
-    } catch {
-        # Fall through to null result
-    }
+        if ($sid) { return $sid }
+    } catch { }
 
     return $null
 }
 
 function Remove-UserData {
-    param(
-        [string[]]$AdditionalPaths = @()
-    )
-
     $userProfiles = Get-UserProfileDirectories
     $targets = @()
 
     foreach ($userProfile in $userProfiles) {
         $profilePath = $userProfile.FullName
-        $userProfileTargets = @(
+        $targets += @(
             (Join-Path -Path $profilePath -ChildPath 'AppData\Local\Lenovo\Lenovo AI Now'),
             (Join-Path -Path $profilePath -ChildPath 'AppData\Local\Lenovo\LenovoAI Now'),
             (Join-Path -Path $profilePath -ChildPath 'AppData\Local\Lenovo\AI Now'),
@@ -458,9 +551,7 @@ function Remove-UserData {
             (Join-Path -Path $profilePath -ChildPath 'AppData\Roaming\Lenovo\LenovoAI Now'),
             (Join-Path -Path $profilePath -ChildPath 'AppData\Roaming\Lenovo\AI Now')
         )
-        $targets += $userProfileTargets
-        
-        # Clean user registry entries
+
         $userSid = Resolve-UserProfileSid -LocalPath $profilePath -ProfileName $userProfile.Name
         if ($userSid) {
             $userRegPaths = @(
@@ -469,7 +560,6 @@ function Remove-UserData {
                 "Registry::HKEY_USERS\$userSid\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\Lenovo AI Now",
                 "Registry::HKEY_USERS\$userSid\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\LenovoAINow"
             )
-            
             foreach ($regPath in $userRegPaths) {
                 if (Test-Path -Path $regPath) {
                     try {
@@ -485,16 +575,10 @@ function Remove-UserData {
         }
     }
 
-    if ($AdditionalPaths) {
-        $targets += $AdditionalPaths
-    }
-
     foreach ($target in $targets | Where-Object { $_ } | Select-Object -Unique) {
-        if (Remove-DirectoryWithRetry -Path $target) {
-            continue
+        if (-not (Remove-DirectoryWithRetry -Path $target)) {
+            Write-Log "Unable to remove user data directory $target." "WARNING"
         }
-
-        Write-Log "Unable to remove user data directory $target after multiple attempts." "WARNING"
     }
 }
 
@@ -504,35 +588,23 @@ function Remove-StartMenuShortcuts {
         'C:\ProgramData\Microsoft\Windows\Start Menu\Programs',
         'C:\Users\Public\Desktop'
     )
-
     foreach ($userProfile in Get-UserProfileDirectories) {
-        $profileShortcuts = @(
-            (Join-Path -Path $userProfile.FullName -ChildPath 'AppData\Roaming\Microsoft\Windows\Start Menu'),
-            (Join-Path -Path $userProfile.FullName -ChildPath 'AppData\Roaming\Microsoft\Windows\Start Menu\Programs'),
-            (Join-Path -Path $userProfile.FullName -ChildPath 'Desktop')
+        $shortcutRoots += @(
+            (Join-Path $userProfile.FullName 'AppData\Roaming\Microsoft\Windows\Start Menu'),
+            (Join-Path $userProfile.FullName 'AppData\Roaming\Microsoft\Windows\Start Menu\Programs'),
+            (Join-Path $userProfile.FullName 'Desktop')
         )
-        $shortcutRoots += $profileShortcuts
     }
-
-    $shortcutRoots = $shortcutRoots |
-        Where-Object { $_ } |
-        Select-Object -Unique
+    $shortcutRoots = $shortcutRoots | Where-Object { $_ } | Select-Object -Unique
 
     foreach ($root in $shortcutRoots) {
-        if (-not (Test-Path -Path $root)) {
-            continue
-        }
-
+        if (-not (Test-Path -Path $root)) { continue }
         try {
-            $shortcuts = @()
-            $shortcuts += Get-ChildItem -Path $root -Filter '*Lenovo*AI*Now*.lnk' -Recurse -ErrorAction SilentlyContinue
-            $shortcuts += Get-ChildItem -Path $root -Filter '*LenovoAI*.lnk' -Recurse -ErrorAction SilentlyContinue
-            $shortcuts += Get-ChildItem -Path $root -Filter '*Lenovo*AI*.lnk' -Recurse -ErrorAction SilentlyContinue
+            $shortcuts = @(Get-ChildItem -Path $root -Filter '*Lenovo*AI*.lnk' -Recurse -ErrorAction SilentlyContinue)
         } catch {
             Write-Log "Failed to enumerate shortcuts under $root : $($_.Exception.Message)"
             continue
         }
-
         foreach ($shortcut in $shortcuts) {
             try {
                 Write-Log "Removing shortcut $($shortcut.FullName)"
@@ -544,103 +616,6 @@ function Remove-StartMenuShortcuts {
     }
 }
 
-function Invoke-Uninstaller {
-    param(
-        [string]$FilePath,
-        [string[]]$ArgumentCandidates,
-        [int]$TimeoutSeconds = 300
-    )
-
-    if (-not (Test-Path -Path $FilePath)) {
-        Write-Log "Uninstaller not found at $FilePath"
-        return $false
-    }
-
-    $uniqueArgs = $ArgumentCandidates |
-        Where-Object { $_ } |
-        Select-Object -Unique
-
-    if (-not $uniqueArgs) {
-        Write-Log 'No argument candidates supplied; skipping uninstaller invocation to avoid interactive prompts.'
-        return $false
-    }
-
-    foreach ($candidateArgs in $uniqueArgs) {
-        $displayArgs = if ([string]::IsNullOrWhiteSpace($candidateArgs)) { '(no arguments)' } else { $candidateArgs }
-        Write-Log "Attempting to run $FilePath with arguments: $displayArgs"
-
-        try {
-            $process = Start-Process -FilePath $FilePath -ArgumentList $candidateArgs -PassThru -WindowStyle Hidden
-        } catch {
-            Write-Log "Failed to launch uninstaller: $($_.Exception.Message)"
-            continue
-        }
-
-        try {
-            $exited = $process.WaitForExit($TimeoutSeconds * 1000)
-        } catch {
-            Write-Log "Error waiting for uninstaller to exit: $($_.Exception.Message)"
-            $exited = $false
-        }
-
-        if (-not $exited) {
-            Write-Log "Uninstaller did not exit within $TimeoutSeconds seconds. Terminating process."
-            try {
-                Stop-Process -Id $process.Id -Force -ErrorAction Stop
-            } catch {
-                Write-Log "Failed to terminate uninstaller process: $($_.Exception.Message)"
-            }
-            continue
-        }
-
-        Write-Log "Uninstaller exited with code $($process.ExitCode)"
-        if ($process.ExitCode -eq 0) {
-            return $true
-        }
-    }
-
-    return $false
-}
-
-function Invoke-MsiUninstall {
-    param(
-        [string]$UninstallCommand
-    )
-
-    if ($UninstallCommand -notmatch '(?i)msiexec\.exe') {
-        return $false
-    }
-
-    if ($UninstallCommand -match '{[0-9A-Fa-f-]+}') {
-        $productCode = $matches[0]
-    } else {
-        Write-Log "MSI uninstall string detected but product code missing. Raw command: $UninstallCommand"
-        return $false
-    }
-
-    $arguments = "/x $productCode /qn /norestart"
-    Write-Log "Invoking MSI uninstall: msiexec.exe $arguments"
-    try {
-        $process = Start-Process -FilePath 'msiexec.exe' -ArgumentList $arguments -PassThru -WindowStyle Hidden
-        $exited = $process.WaitForExit(300 * 1000)
-        if (-not $exited) {
-            Write-Log 'MSI uninstall timed out after 300 seconds.'
-            try {
-                Stop-Process -Id $process.Id -Force -ErrorAction Stop
-            } catch {
-                Write-Log "Failed to terminate MSI process: $($_.Exception.Message)"
-            }
-            return $false
-        }
-
-        Write-Log "MSI uninstall exit code: $($process.ExitCode)"
-        return ($process.ExitCode -eq 0)
-    } catch {
-        Write-Log "Failed to run msiexec: $($_.Exception.Message)"
-        return $false
-    }
-}
-
 function Remove-Residuals {
     param(
         [string[]]$InstallPaths,
@@ -648,104 +623,139 @@ function Remove-Residuals {
     )
 
     foreach ($path in $InstallPaths | Where-Object { $_ }) {
-        if (-not (Test-Path -Path $path)) {
-            continue
-        }
-
-        $maxAttempts = 3
-        $removed = $false
-
-        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-            try {
-                Write-Log "Removing residual directory $path (attempt $attempt of $maxAttempts)"
-                Remove-Item -Path $path -Recurse -Force -ErrorAction Stop
-                $removed = $true
-                break
-            } catch {
-                Write-Log "Failed to remove directory $($path): $($_.Exception.Message)"
-                if ($attempt -lt $maxAttempts) {
-                    Stop-ServicesUnderPaths -Paths @($path)
-                    Stop-ProcessesUnderPaths -Paths @($path)
-                    Start-Sleep -Seconds 5
-                }
-            }
-        }
-
-        if (-not $removed) {
-            Write-Log "Unable to remove directory $($path) after $maxAttempts attempts." "WARNING"
+        if (-not (Test-Path -Path $path)) { continue }
+        if (-not (Remove-DirectoryWithRetry -Path $path)) {
+            Write-Log "Could not remove directory $path in-session; will queue for boot delete." "WARNING"
         }
     }
 
     foreach ($regPath in $RegistryPaths | Where-Object { $_ }) {
-        if (-not (Test-Path -Path $regPath)) {
-            continue
-        }
-
+        if (-not (Test-Path -Path $regPath)) { continue }
         try {
             Write-Log "Removing residual registry key $regPath"
             Remove-Item -Path $regPath -Recurse -Force -ErrorAction Stop
         } catch {
-            Write-Log "Failed to remove registry key $($regPath): $($_.Exception.Message)"
+            Write-Log "Failed to remove registry key $regPath : $($_.Exception.Message)"
         }
     }
 }
 
 function Remove-LenovoAIServices {
     try {
-        $services = Get-CimInstance Win32_Service -ErrorAction Stop | Where-Object {
-            $_.Name -match '(?i)lenovo.*ai.*now' -or 
+        $services = @(Get-CimInstance Win32_Service -ErrorAction Stop | Where-Object {
+            $_.Name -match '(?i)lenovo.*ai.*now' -or
             $_.Name -match '(?i)lenovoai' -or
             $_.DisplayName -match '(?i)lenovo.*ai.*now'
-        }
-        
+        })
+
         foreach ($service in $services) {
-            try {
-                if ($service.State -eq 'Running') {
-                    Write-Log "Stopping service $($service.Name)"
-                    Stop-Service -Name $service.Name -Force -ErrorAction Stop
-                }
-                
-                Write-Log "Removing service $($service.Name)"
-                $deleteResult = Start-Process -FilePath 'sc.exe' -ArgumentList "delete `"$($service.Name)`"" -WindowStyle Hidden -Wait -PassThru
-                if ($deleteResult.ExitCode -ne 0) {
-                    Write-Log "Service deletion returned non-zero exit code: $($deleteResult.ExitCode)"
-                }
-            } catch {
-                Write-Log "Failed to remove service $($service.Name): $($_.Exception.Message)"
-            }
+            Write-Log "Cleaning up Lenovo AI service: $($service.Name) ($($service.DisplayName))"
+            Disable-AndStopService -Name $service.Name
         }
     } catch {
         Write-Log "Error enumerating services for removal: $($_.Exception.Message)"
     }
 }
 
-function Remove-ScheduledTasks {
+function Remove-LenovoAINowAppxPackages {
+    # Removes the AINowContextWIN11 MSIX (and any sibling). Remove-AppxPackage
+    # terminates the package's processes (AINow.Service.exe etc.) as part of
+    # removal so we don't need to kill them manually.
     try {
-        $tasks = Get-ScheduledTask -ErrorAction SilentlyContinue | Where-Object {
-            $_.TaskName -match '(?i)lenovo.*ai.*now' -or 
-            $_.TaskName -match '(?i)lenovoai'
-        }
-        
-        # Also check task actions if available
-        foreach ($task in (Get-ScheduledTask -ErrorAction SilentlyContinue)) {
+        $packages = @(Get-AppxPackage -AllUsers -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -like '*AINow*' -or $_.Name -like '*LenovoAI*' })
+        foreach ($pkg in $packages) {
             try {
-                $actions = $task.Actions
-                if ($actions) {
-                    foreach ($action in $actions) {
-                        if ($action.Execute -and $action.Execute -match '(?i)lenovo.*ai.*now') {
-                            $tasks += $task
-                            break
-                        }
-                    }
-                }
+                Write-Log "Removing AppX package $($pkg.PackageFullName) for all users."
+                Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers -ErrorAction Stop
             } catch {
-                # Skip tasks where we can't read actions
-                continue
+                Write-Log "Remove-AppxPackage failed for $($pkg.PackageFullName): $($_.Exception.Message)"
             }
         }
-        
+    } catch {
+        Write-Log "Error enumerating AppX packages: $($_.Exception.Message)"
+    }
+
+    try {
+        $provisioned = @(Get-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue |
+            Where-Object { $_.PackageName -like '*AINow*' -or $_.DisplayName -like '*Lenovo*AI*' })
+        foreach ($pkg in $provisioned) {
+            try {
+                Write-Log "Removing provisioned AppX package $($pkg.PackageName)."
+                Remove-AppxProvisionedPackage -Online -PackageName $pkg.PackageName -ErrorAction Stop | Out-Null
+            } catch {
+                Write-Log "Remove-AppxProvisionedPackage failed for $($pkg.PackageName): $($_.Exception.Message)"
+            }
+        }
+    } catch {
+        # Some PowerShell hosts lack the DISM module; this is best-effort.
+    }
+}
+
+function Remove-LenovoAINowAppxRepositoryStubs {
+    # Remove orphaned AppX repository entries left behind by
+    # Remove-AppxPackage. Microsoft's AppX uninstall doesn't reliably
+    # clean these, so Get-AppxPackage returns nothing while a per-user
+    # registry stub still references C:\Program Files\Lenovo\Lenovo AI Now.
+    # Functionally harmless but a real residual; can confuse reinstalls.
+    Write-Log 'Scrubbing orphaned AppX repository entries.'
+
+    foreach ($userProfile in Get-UserProfileDirectories) {
+        $userSid = Resolve-UserProfileSid -LocalPath $userProfile.FullName -ProfileName $userProfile.Name
+        if (-not $userSid) { continue }
+        $repoPath = "Registry::HKEY_USERS\$userSid\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\Repository\Packages"
+        if (-not (Test-Path -LiteralPath $repoPath)) { continue }
+        foreach ($entry in Get-ChildItem -LiteralPath $repoPath -ErrorAction SilentlyContinue) {
+            if ($entry.PSChildName -like '*AINow*' -or $entry.PSChildName -like '*LenovoAI*') {
+                try {
+                    Write-Log "Removing orphaned per-user AppX repository entry: $($entry.PSChildName) (user: $($userProfile.Name))"
+                    Remove-Item -LiteralPath $entry.PSPath -Recurse -Force -ErrorAction Stop
+                } catch {
+                    Write-Log "Failed to remove $($entry.PSPath): $($_.Exception.Message)"
+                }
+            }
+        }
+    }
+
+    foreach ($root in @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\Applications',
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\Deprovisioned',
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\InboxApplications'
+    )) {
+        if (-not (Test-Path -LiteralPath $root)) { continue }
+        foreach ($entry in Get-ChildItem -LiteralPath $root -ErrorAction SilentlyContinue) {
+            if ($entry.PSChildName -like '*AINow*' -or $entry.PSChildName -like '*LenovoAI*') {
+                try {
+                    Write-Log "Removing orphaned HKLM AppX entry: $($entry.PSPath)"
+                    Remove-Item -LiteralPath $entry.PSPath -Recurse -Force -ErrorAction Stop
+                } catch {
+                    Write-Log "Failed to remove $($entry.PSPath): $($_.Exception.Message)"
+                }
+            }
+        }
+    }
+}
+
+function Remove-ScheduledTasks {
+    try {
+        $tasks = @(Get-ScheduledTask -ErrorAction SilentlyContinue | Where-Object {
+            $_.TaskName -match '(?i)lenovo.*ai.*now' -or
+            $_.TaskName -match '(?i)lenovoai'
+        })
+
+        foreach ($task in (Get-ScheduledTask -ErrorAction SilentlyContinue)) {
+            try {
+                foreach ($action in @($task.Actions)) {
+                    if ($action.PSObject.Properties['Execute'] -and
+                        $action.Execute -and ($action.Execute -match '(?i)lenovo.*ai.*now')) {
+                        $tasks += $task
+                        break
+                    }
+                }
+            } catch { continue }
+        }
+
         $tasks = $tasks | Select-Object -Unique
-        
         foreach ($task in $tasks) {
             try {
                 Write-Log "Removing scheduled task: $($task.TaskName)"
@@ -759,54 +769,221 @@ function Remove-ScheduledTasks {
     }
 }
 
-function Unregister-LenovoAIShellExtensions {
-    Write-Log 'Unregistering Lenovo AI Now shell extensions.'
-    
+function Test-IsLenovoAIDllPath {
+    # Returns $true if the given DLL path is one of the known Lenovo AI
+    # filenames AND lives under a Lenovo AI* product directory.
+    #
+    # The path anchor is `\Lenovo\Lenovo AI` rather than just `\Lenovo\`
+    # so we don't match DLLs from other Lenovo products (Vantage, Now,
+    # Commercial Vantage, etc.) that may ship a generically-named
+    # OverlayIcon.dll. Still matches future variants like
+    # "Lenovo AI Now Plus", "Lenovo AI Solution", etc.
+    param([string]$DllPath)
+    if (-not $DllPath) { return $false }
+    $leaf = [IO.Path]::GetFileName($DllPath)
+    if (-not ($lenovoAIDllFileNames -contains $leaf)) { return $false }
+    if ($DllPath -notmatch '(?i)\\Lenovo\\Lenovo AI') { return $false }
+    return $true
+}
+
+function Get-LenovoAIClsidsFromHive {
+    # Enumerate one CLSID hive and return GUIDs whose InprocServer32
+    # default value resolves to a Lenovo AI DLL under a Lenovo AI*
+    # product directory.
+    #
+    # Uses the .NET Microsoft.Win32.Registry API rather than Get-ChildItem
+    # because the cmdlet path adds ~40s per 7k-key hive of PS provider
+    # overhead, while the .NET path completes in ~200ms on the same data.
+    #
+    # $ClsidRoot is a relative HKLM path (e.g. 'SOFTWARE\Classes\CLSID'),
+    # not a PS provider path.
+    param([Parameter(Mandatory)][string]$ClsidRoot)
+
+    $found = New-Object System.Collections.Generic.List[string]
+    $root = $null
     try {
-        # Find all CLSIDs that point to Lenovo AI Now DLLs
-        $clsidRoot = 'HKLM:\SOFTWARE\Classes\CLSID'
-        if (Test-Path -Path $clsidRoot) {
-            $lenovoClsids = Get-ChildItem -Path $clsidRoot -ErrorAction SilentlyContinue | 
-                Where-Object { 
-                    try {
-                        $inprocServer = Get-ItemProperty -Path "$($_.PSPath)\InprocServer32" -ErrorAction SilentlyContinue
-                        if ($inprocServer -and $inprocServer.'(Default)') {
-                            $inprocServer.'(Default)' -match '(?i)lenovo.*ai.*now'
-                        }
-                    } catch {
-                        $false
+        $root = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($ClsidRoot, $false)
+    } catch {
+        Write-Log "Failed to open registry $ClsidRoot : $($_.Exception.Message)" "DEBUG"
+        return $found
+    }
+    if ($null -eq $root) { return $found }
+
+    try {
+        foreach ($name in $root.GetSubKeyNames()) {
+            $sub = $null
+            try {
+                $sub = $root.OpenSubKey("$name\InprocServer32", $false)
+                if ($null -ne $sub) {
+                    $dll = $sub.GetValue($null)
+                    if ($dll -and (Test-IsLenovoAIDllPath -DllPath $dll)) {
+                        $found.Add($name) | Out-Null
                     }
                 }
-            
-            foreach ($clsid in $lenovoClsids) {
+            } catch {
+                # individual subkey failures ignored
+            } finally {
+                if ($null -ne $sub) { $sub.Close() }
+            }
+        }
+    } finally {
+        $root.Close()
+    }
+    return $found
+}
+
+function Unregister-LenovoAIShellExtensions {
+    Write-Log 'Unregistering Lenovo AI Now shell extensions.'
+
+    # Build the union of: hardcoded known CLSIDs + filename-discovered
+    # CLSIDs from both 64-bit and 32-bit hives. Discovery is via the .NET
+    # registry API (~200ms per hive) and anchored by Test-IsLenovoAIDllPath
+    # to a Lenovo AI* product directory, so it can't pick up DLLs from
+    # other Lenovo products or unrelated vendors.
+    $allClsids = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
+    foreach ($g in $knownLenovoAIClsids) {
+        [void]$allClsids.Add($g)
+    }
+
+    foreach ($hive in @('SOFTWARE\Classes\CLSID',
+                        'SOFTWARE\Classes\Wow6432Node\CLSID')) {
+        foreach ($g in Get-LenovoAIClsidsFromHive -ClsidRoot $hive) {
+            if ($allClsids.Add($g)) {
+                Write-Log "Discovered additional Lenovo AI CLSID: $g (hive: $hive)"
+            }
+        }
+    }
+
+    # 1) Remove ShellIconOverlayIdentifiers subkeys that point to a Lenovo
+    #    CLSID. Subkey names may have leading whitespace (Lenovo prefixes
+    #    with spaces so its overlay sorts before the 15-slot limit).
+    $overlayRoots = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\ShellIconOverlayIdentifiers',
+        'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\ShellIconOverlayIdentifiers'
+    )
+    foreach ($root in $overlayRoots) {
+        if (-not (Test-Path -Path $root)) { continue }
+        foreach ($entry in Get-ChildItem -Path $root -ErrorAction SilentlyContinue) {
+            try {
+                $clsidValue = $null
                 try {
-                    Write-Log "Unregistering shell extension CLSID: $($clsid.PSChildName)"
-                    # Remove the CLSID registration
-                    Remove-Item -Path $clsid.PSPath -Recurse -Force -ErrorAction Stop
+                    $clsidValue = Get-ItemPropertyValue -Path $entry.PSPath -Name '(default)' -ErrorAction Stop
+                } catch { }
+                $nameLooksLenovo = ($entry.PSChildName -match '(?i)lenovo' -or $entry.PSChildName -match '(?i)ainow')
+                if (($clsidValue -and $allClsids.Contains($clsidValue)) -or $nameLooksLenovo) {
+                    Write-Log "Removing ShellIconOverlayIdentifiers entry: $($entry.PSChildName) (CLSID $clsidValue)"
+                    Remove-Item -Path $entry.PSPath -Recurse -Force -ErrorAction Stop
+                }
+            } catch {
+                Write-Log "Failed to inspect overlay identifier $($entry.PSChildName): $($_.Exception.Message)"
+            }
+        }
+    }
+
+    # 2) Remove value names matching Lenovo CLSIDs from the Approved list.
+    foreach ($approvedKey in @('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved',
+                                'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved')) {
+        if (-not (Test-Path -Path $approvedKey)) { continue }
+        try {
+            $approved = Get-Item -Path $approvedKey -ErrorAction Stop
+            foreach ($valueName in $approved.GetValueNames()) {
+                if ($allClsids.Contains($valueName)) {
+                    try {
+                        Write-Log "Removing Approved shell extension value: $valueName"
+                        Remove-ItemProperty -Path $approvedKey -Name $valueName -ErrorAction Stop
+                    } catch {
+                        Write-Log "Failed to remove Approved value $valueName : $($_.Exception.Message)"
+                    }
+                }
+            }
+        } catch {
+            Write-Log "Failed to enumerate Approved key $approvedKey : $($_.Exception.Message)"
+        }
+    }
+
+    # 3) Remove shellex ContextMenuHandlers / DragDropHandlers under each
+    #    file-type root. Hardcoded list covers the known surface; we also
+    #    sweep dynamically for any subkey whose value matches a Lenovo CLSID.
+    #
+    # CRITICAL: many of these paths include the literal `*` file-type root
+    # (the registration for "all files"). PowerShell's -Path parameter
+    # treats * as a wildcard and would expand it across hundreds of
+    # HKCR subkeys, taking minutes. Use -LiteralPath throughout.
+    foreach ($key in $knownLenovoAIShellexKeys) {
+        if (Test-Path -LiteralPath $key) {
+            try {
+                Write-Log "Removing shellex handler $key"
+                Remove-Item -LiteralPath $key -Recurse -Force -ErrorAction Stop
+            } catch {
+                Write-Log "Failed to remove $key : $($_.Exception.Message)"
+            }
+        }
+    }
+
+    foreach ($fileType in @('*', 'AllFilesystemObjects', 'Directory', 'Drive', 'Folder', 'lnkfile')) {
+        foreach ($handlerType in @('ContextMenuHandlers', 'DragDropHandlers', 'PropertySheetHandlers')) {
+            $handlerRoot = "HKLM:\SOFTWARE\Classes\$fileType\shellex\$handlerType"
+            if (-not (Test-Path -LiteralPath $handlerRoot)) { continue }
+            foreach ($entry in Get-ChildItem -LiteralPath $handlerRoot -ErrorAction SilentlyContinue) {
+                try {
+                    $clsidValue = $null
+                    try {
+                        $clsidValue = Get-ItemPropertyValue -LiteralPath $entry.PSPath -Name '(default)' -ErrorAction Stop
+                    } catch { }
+                    if ($clsidValue -and $allClsids.Contains($clsidValue)) {
+                        Write-Log "Removing shellex handler $($entry.PSPath) -> $clsidValue"
+                        Remove-Item -LiteralPath $entry.PSPath -Recurse -Force -ErrorAction Stop
+                    }
                 } catch {
-                    Write-Log "Failed to unregister CLSID $($clsid.PSChildName): $($_.Exception.Message)"
+                    Write-Log "Failed to inspect shellex entry $($entry.PSChildName): $($_.Exception.Message)"
                 }
             }
         }
-    } catch {
-        Write-Log "Error unregistering shell extensions: $($_.Exception.Message)"
+    }
+
+    # 4) Remove the CLSID subtrees themselves (both hives), plus AppID,
+    #    TypeLib, ProgID satellites.
+    foreach ($clsid in $allClsids) {
+        foreach ($hive in @('HKLM:\SOFTWARE\Classes\CLSID',
+                            'HKLM:\SOFTWARE\Classes\Wow6432Node\CLSID')) {
+            $path = Join-Path $hive $clsid
+            if (Test-Path -Path $path) {
+                try {
+                    Write-Log "Removing CLSID subtree $path"
+                    Remove-Item -Path $path -Recurse -Force -ErrorAction Stop
+                } catch {
+                    Write-Log "Failed to remove $path : $($_.Exception.Message)"
+                }
+            }
+        }
+    }
+
+    foreach ($satellite in $knownLenovoAISatelliteKeys) {
+        if (Test-Path -Path $satellite) {
+            try {
+                Write-Log "Removing satellite COM key $satellite"
+                Remove-Item -Path $satellite -Recurse -Force -ErrorAction Stop
+            } catch {
+                Write-Log "Failed to remove $satellite : $($_.Exception.Message)"
+            }
+        }
     }
 }
 
 function Invoke-LenovoAiNowRemediation {
     Write-Log 'Starting Lenovo AI Now remediation.'
 
-    $entries = Get-LenovoAiNowEntries
+    $entries = @(Get-LenovoAiNowEntries)
     $installPaths = @()
     if ($entries) {
-        $installPaths += ($entries | ForEach-Object {
-            if ($_.PSObject.Properties['InstallLocation'] -and $_.InstallLocation) {
-                $_.InstallLocation
+        foreach ($e in $entries) {
+            if ($e.PSObject.Properties['InstallLocation'] -and $e.InstallLocation) {
+                $installPaths += $e.InstallLocation
             }
-        })
+        }
     }
     $installPaths += $defaultInstallPaths
-    $installPaths = $installPaths | Where-Object { $_ } | Select-Object -Unique
+    $installPaths = @($installPaths | Where-Object { $_ } | Select-Object -Unique)
 
     foreach ($path in $installPaths) {
         Write-Log "Detected potential install path: $path"
@@ -814,54 +991,48 @@ function Invoke-LenovoAiNowRemediation {
 
     $pathExists = $false
     foreach ($path in $installPaths) {
-        if (Test-Path -Path $path) {
-            $pathExists = $true
-            break
-        }
+        if (Test-Path -Path $path) { $pathExists = $true; break }
     }
 
-    if (-not $pathExists -and -not $entries) {
-        Write-Log -Level 'INFO' -Message "REMEDIATION SUCCESSFUL: Lenovo AI Now is already absent from the system."
+    $appxPresent = $false
+    try {
+        $appxPresent = $null -ne (Get-AppxPackage -AllUsers -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -like '*AINow*' -or $_.Name -like '*LenovoAI*' } |
+            Select-Object -First 1)
+    } catch { }
+
+    if (-not $pathExists -and -not $entries -and -not $appxPresent) {
+        Write-Log "Lenovo AI Now is already absent from the system."
+        # Belt-and-braces: still scrub user-profile leftovers, straggling
+        # shortcuts, and any orphaned AppX repository stubs.
         Remove-UserData
         Remove-StartMenuShortcuts
+        Remove-LenovoAINowAppxRepositoryStubs
+        Clear-PhaseACompleteSentinel
         return 0
     }
 
-    if ($entries) {
-        Write-Log 'Registry entries detected for Lenovo AI Now.'
-    }
+    if ($entries) { Write-Log 'Registry entries detected for Lenovo AI Now.' }
 
-    Write-Log 'Skipping vendor uninstaller due to interactive-only experience; proceeding with manual cleanup.'
-
-    $processExecutables = @(
-        'lenovo ainow.exe',
-        'lenovo ainow helper.exe',
-        'lenovo ainow service.exe',
-        'lenovo ainow utility.exe',
-        'lenovo ainow mini.exe',
-        'lenovo ainow oobe.exe',
-        'lenovo ainow safetychecker.exe',
-        'lenovo ainow launcher.exe',
-        'lenovoainow.exe'
-    )
-
+    # Stop processes (path + executable name) and services across the install
+    # paths. Then remove the MSIX (which also terminates any of its own
+    # processes including AINow.Service.exe under WindowsApps).
     Stop-ServicesUnderPaths -Paths $installPaths
     Stop-ProcessesUnderPaths -Paths $installPaths -ExecutableNames $processExecutables
     Stop-ProcessesUnderPaths -Paths @() -ExecutableNames $processExecutables
 
     Remove-LenovoAIServices
+    Remove-LenovoAINowAppxPackages
+    Remove-LenovoAINowAppxRepositoryStubs
+
     Unregister-LenovoAIShellExtensions
     Remove-UserData
     Remove-StartMenuShortcuts
     Remove-ScheduledTasks
 
     $registryPaths = @()
-    if ($entries) {
-        $registryPaths += $entries | ForEach-Object { $_.RegistryPath }
-    }
+    if ($entries) { $registryPaths += $entries | ForEach-Object { $_.RegistryPath } }
     $registryPaths += @(
-        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Lenovo AI Now',
-        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Lenovo AI Now',
         'HKLM:\SOFTWARE\Lenovo\AI Now',
         'HKLM:\SOFTWARE\Lenovo\Lenovo AI Now',
         'HKLM:\SOFTWARE\WOW6432Node\Lenovo\AI Now',
@@ -873,128 +1044,65 @@ function Invoke-LenovoAiNowRemediation {
 
     Remove-Residuals -InstallPaths $installPaths -RegistryPaths $registryPaths
 
-    # Final pass to ensure nothing spun back up before verification.
+    # Final stop pass -- anything that respawned during cleanup gets caught.
     Stop-ServicesUnderPaths -Paths $installPaths
     Stop-ProcessesUnderPaths -Paths $installPaths -ExecutableNames $processExecutables
 
-    $remainingEntries = Get-LenovoAiNowEntries
-    $remainingPaths = $installPaths | Where-Object { Test-Path -Path $_ }
+    # Verify what's left.
+    $remainingEntries = @(Get-LenovoAiNowEntries)
+    $remainingPaths = @($installPaths | Where-Object { Test-Path -Path $_ })
 
-    if ($remainingEntries -or $remainingPaths) {
-        if ($remainingEntries) {
-            foreach ($entry in $remainingEntries) {
-                Write-Log "Residual registry entry still present: $($entry.RegistryPath)" "WARNING"
-            }
-        }
-
-        if ($remainingPaths) {
-            foreach ($path in $remainingPaths) {
-                Write-Log "Residual directory still present: $path" "WARNING"
-                
-                # Try one more aggressive removal attempt
-                try {
-                    Write-Log "Final attempt to remove stubborn directory: $path"
-                    & takeown /f "$path" /r /d y 2>&1 | Out-Null
-                    & icacls "$path" /grant Everyone:F /t 2>&1 | Out-Null
-                    
-                    # Use PowerShell to remove read-only attributes
-                    Get-ChildItem -Path $path -Recurse -Force | ForEach-Object {
-                        $_.Attributes = $_.Attributes -band (-bnot [System.IO.FileAttributes]::ReadOnly)
-                    }
-                    
-                    Remove-Item -Path $path -Recurse -Force -ErrorAction Stop
-                    Write-Log "Successfully removed directory on final attempt: $path"
-                } catch {
-                    Write-Log "Final removal attempt failed for $path : $($_.Exception.Message)" "WARNING"
-                }
-            }
-        }
-
-        # Check again after final cleanup attempts
-        $finalRemainingEntries = Get-LenovoAiNowEntries
-        $finalRemainingPaths = $installPaths | Where-Object { Test-Path -Path $_ }
-        
-        # If we still have stubborn directories, try the Explorer downtime approach
-        foreach ($stubbornPath in $finalRemainingPaths) {
-            try {
-                Write-Log "Attempting Explorer downtime removal for stubborn directory: $stubbornPath"
-                Stop-Process -Name explorer -Force -ErrorAction SilentlyContinue
-                Stop-Process -Name dllhost -Force -ErrorAction SilentlyContinue
-                Start-Sleep -Seconds 3  # Wait for DLLs to unload
-                
-                # Try to delete during the explorer-free window
-                try {
-                    Remove-Item -Path $stubbornPath -Recurse -Force -ErrorAction Stop
-                    Write-Log "Successfully removed stubborn directory during Explorer downtime: $stubbornPath"
-                } catch {
-                    Write-Log "Explorer downtime removal failed for $stubbornPath : $($_.Exception.Message)"
-                }
-                
-                # Always restart Explorer
-                Start-Process explorer -ErrorAction SilentlyContinue
-                Start-Sleep -Seconds 2
-            } catch {
-                Write-Log "Explorer downtime approach failed: $($_.Exception.Message)"
-                # Make sure Explorer is running
-                try {
-                    Start-Process explorer -ErrorAction SilentlyContinue
-                } catch {}
-            }
-        }
-        
-        # Final check after Explorer downtime attempt
-        $finalRemainingEntries = Get-LenovoAiNowEntries
-        $finalRemainingPaths = $installPaths | Where-Object { Test-Path -Path $_ }
-        
-        # Count remaining files to determine if cleanup was successful
-        $totalRemainingFiles = 0
-        foreach ($path in $finalRemainingPaths) {
-            try {
-                $fileCount = (Get-ChildItem -Path $path -Recurse -Force -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer }).Count
-                $totalRemainingFiles += $fileCount
-                Write-Log "Directory $path contains $fileCount remaining files"
-            } catch {
-                Write-Log "Could not count files in $path : $($_.Exception.Message)"
-            }
-        }
-        
-        if ($finalRemainingEntries -or ($totalRemainingFiles -gt 5)) {
-            Write-Log "Lenovo AI Now removal completed with significant residual items remaining." "WARNING"
-            if ($finalRemainingEntries) {
-                Write-Log "Remaining registry entries: $($finalRemainingEntries.Count)" "WARNING"
-            }
-            if ($finalRemainingPaths) {
-                Write-Log "Remaining directories with $totalRemainingFiles total files: $($finalRemainingPaths -join ', ')" "WARNING"
-            }
-            Write-Log "Manual cleanup or system reboot may be required to complete removal." "WARNING"
-            Write-Log -Level 'ERROR' -Message "REMEDIATION PARTIALLY SUCCESSFUL: Some Lenovo AI Now components could not be removed."
-            return 1603  # Partial failure - some components remain
-        } elseif ($totalRemainingFiles -gt 0) {
-            Write-Log "Lenovo AI Now removal completed successfully. $totalRemainingFiles locked files scheduled for deletion on reboot."
-            Write-Log -Level 'INFO' -Message "REMEDIATION SUCCESSFUL: Lenovo AI Now removed. Reboot recommended for complete cleanup."
-            return 3010  # Success but reboot required
-        }
-        
-        Write-Log -Level 'INFO' -Message "REMEDIATION COMPLETELY SUCCESSFUL: All Lenovo AI Now components removed."
-        return 0  # Complete success
-        
-        return 0  # Always return success as we've done our best
+    if ($remainingEntries.Count -eq 0 -and $remainingPaths.Count -eq 0) {
+        Write-Log "REMEDIATION COMPLETELY SUCCESSFUL: All Lenovo AI Now components removed."
+        Clear-PhaseACompleteSentinel
+        return 0
     }
 
-    Write-Log 'Lenovo AI Now successfully removed.'
-    
-    # Ensure Explorer is running to prevent visual glitches
-    try {
-        $explorerProcesses = Get-Process -Name explorer -ErrorAction SilentlyContinue
-        if (-not $explorerProcesses) {
-            Write-Log 'Restarting Explorer to restore desktop functionality.'
-            Start-Process explorer -ErrorAction SilentlyContinue
-        }
-    } catch {
-        Write-Log "Warning: Could not verify Explorer status: $($_.Exception.Message)" "WARNING"
+    foreach ($entry in $remainingEntries) {
+        Write-Log "Residual registry entry still present: $($entry.RegistryPath)" "WARNING"
     }
-    
-    return 0
+    foreach ($p in $remainingPaths) {
+        Write-Log "Residual directory still present: $p" "WARNING"
+    }
+
+    # Queue remaining files + dirs for boot-time deletion. Bottom-up order
+    # so SMSS deletes children before parents.
+    $allFiles = @()
+    $allDirs = @()
+    foreach ($p in $remainingPaths) {
+        $candidates = Get-PendingDeleteCandidates -Path $p
+        $allFiles += $candidates.Files
+        $allDirs += $candidates.Directories
+    }
+
+    # Rename files to *.tobedeleted so detect.ps1 can exclude them from its
+    # file count and not retrigger remediation between Phase A and reboot.
+    $renamedFiles = @()
+    foreach ($file in $allFiles) {
+        $renamed = $file
+        if ($file -notmatch '\.tobedeleted$') {
+            $candidate = "$file.tobedeleted"
+            try {
+                Move-Item -Path $file -Destination $candidate -Force -ErrorAction Stop
+                $renamed = $candidate
+            } catch {
+                # Can't rename (locked) -- queue under original name.
+            }
+        }
+        $renamedFiles += $renamed
+    }
+
+    $queued = Add-PendingFileDeleteBatch -FilePaths $renamedFiles -DirectoryPaths $allDirs
+
+    if ($queued -gt 0) {
+        Set-PhaseACompleteSentinel
+        Write-Log "REMEDIATION SUCCESSFUL: pending reboot to complete removal of $queued items."
+        return 3010
+    }
+
+    # Nothing got queued (write failed) and residuals remain -- true partial.
+    Write-Log "REMEDIATION PARTIALLY SUCCESSFUL: residuals remain and PFRO queue failed." "ERROR"
+    return 1603
 }
 
 $exitCode = 0
@@ -1005,21 +1113,20 @@ try {
         $exitCode = $remediationResult
     }
 
-    # Log final status based on exit code
     switch ($exitCode) {
-        0 { 
+        0 {
             Write-Log "Script completed successfully with exit code 0" "INFO"
             $intuneExitCode = 0
         }
-        3010 { 
-            Write-Log "Script completed with exit code 3010 (reboot recommended)" "INFO"
+        3010 {
+            Write-Log "Script completed with exit code 3010 (reboot required to finish removal)" "INFO"
             $intuneExitCode = 0
         }
-        1603 { 
+        1603 {
             Write-Log "Script completed with exit code 1603 (partial failure)" "WARNING"
             $intuneExitCode = 1
         }
-        default { 
+        default {
             Write-Log "Script completed with unexpected exit code $exitCode" "ERROR"
             $intuneExitCode = 1
         }

--- a/tools/diagnose_clsid_walk.ps1
+++ b/tools/diagnose_clsid_walk.ps1
@@ -1,0 +1,67 @@
+# Diagnostic: measure how long the CLSID hive walk takes on this device.
+# Compares the old PowerShell cmdlet approach against direct .NET registry
+# API calls. If the cmdlet walk is multiple minutes here, we know that was
+# the hang in Unregister-LenovoAIShellExtensions on this machine.
+#
+# Read-only. Does not modify the registry.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'SilentlyContinue'
+
+Write-Host "=== CLSID walk diagnostic ===" -ForegroundColor Cyan
+Write-Host "Host: $env:COMPUTERNAME    PowerShell: $($PSVersionTable.PSVersion)"
+Write-Host ""
+
+# --- 1. Count CLSIDs ---
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+$total = (Get-ChildItem 'HKLM:\SOFTWARE\Classes\CLSID' -ErrorAction SilentlyContinue | Measure-Object).Count
+$sw.Stop()
+Write-Host ("Get-ChildItem on HKLM:\SOFTWARE\Classes\CLSID  ->  {0} subkeys in {1:N2}s" -f $total, $sw.Elapsed.TotalSeconds)
+
+# --- 2. Time the per-key inspection that the old function did, on a 200-key sample ---
+$sample = 200
+$sw.Restart()
+$matchCount = 0
+foreach ($clsid in Get-ChildItem 'HKLM:\SOFTWARE\Classes\CLSID' -ErrorAction SilentlyContinue | Select-Object -First $sample) {
+    try {
+        $serverPath = Join-Path $clsid.PSPath 'InprocServer32'
+        if (-not (Test-Path -Path $serverPath)) { continue }
+        try {
+            $dll = Get-ItemPropertyValue -Path $serverPath -Name '(default)' -ErrorAction Stop
+            if ($dll -and ($dll -like '*Lenovo*AI*Now*')) { $matchCount++ }
+        } catch { continue }
+    } catch { }
+}
+$sw.Stop()
+$cmdletMsPerKey = $sw.Elapsed.TotalMilliseconds / $sample
+$cmdletExtrapMin = ($cmdletMsPerKey * $total) / 60000.0
+Write-Host ("Cmdlet path:  {0} sample keys in {1:N2}s  ->  {2:N1} ms/key  ->  extrapolated full walk {3:N1} min" -f $sample, $sw.Elapsed.TotalSeconds, $cmdletMsPerKey, $cmdletExtrapMin)
+
+# --- 3. Same scan via direct .NET RegistryKey API (no PS provider overhead) ---
+$sw.Restart()
+$dotnetMatches = New-Object System.Collections.Generic.List[string]
+$root = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SOFTWARE\Classes\CLSID', $false)
+try {
+    foreach ($name in $root.GetSubKeyNames()) {
+        try {
+            $sub = $root.OpenSubKey("$name\InprocServer32", $false)
+            if ($null -ne $sub) {
+                try {
+                    $dll = $sub.GetValue($null)
+                    if ($dll -and ($dll -like '*Lenovo*AI*Now*')) { $dotnetMatches.Add($name) | Out-Null }
+                } finally { $sub.Close() }
+            }
+        } catch { }
+    }
+} finally { $root.Close() }
+$sw.Stop()
+Write-Host ("DotNet path:  full walk of {0} keys in {1:N2}s  ({2} matches)" -f $total, $sw.Elapsed.TotalSeconds, $dotnetMatches.Count)
+foreach ($m in $dotnetMatches) { Write-Host "    matched CLSID: $m" }
+
+Write-Host ""
+Write-Host "Verdict:" -ForegroundColor Cyan
+if ($cmdletExtrapMin -gt 5) {
+    Write-Host "  Cmdlet walk would take >5 min on this device. Hardcoded-CLSIDs-only path is the right fix." -ForegroundColor Yellow
+} else {
+    Write-Host "  Cmdlet walk would finish in $([math]::Round($cmdletExtrapMin,1)) min on this device. If the script still hung, the bottleneck is elsewhere." -ForegroundColor Yellow
+}


### PR DESCRIPTION
Fixes #1

## Summary

Substantial rewrite to handle the case where Lenovo AI Now's shell-extension DLLs are loaded into other shell-using processes (Explorer, Office, browsers, anything that opens a file dialog) and can't be deleted in-session. The existing approach loses against `AutoRestartShell` when killing Explorer and can't unload the DLLs from the 17+ other consumers anyway, so most devices end up with 270 residual files and exit 1603 after every remediation cycle.

This PR pivots the remediation to `PendingFileRenameOperations` + reboot as the primary path. Validated end-to-end on two real Lenovo devices.

## Major changes

- **Two-phase model**: Phase A cleans what's cleanable in-session and queues locked files via PFRO, writes a sentinel registry value, returns 3010 (Intune-compatible success). Phase B happens after the user's organic reboot — SMSS clears the install dir at next boot before any shell process exists, next detect cycle confirms.
- **Self-relaunch under 64-bit PowerShell**. Intune defaults Proactive Remediation scripts to 32-bit, which silently WOW64-redirects `HKLM:\SOFTWARE` reads to `Wow6432Node`. The AI Now uninstall key and all three shell-ext CLSIDs live in the 64-bit hive, so a 32-bit script ran blind and cleaned nothing.
- **Full COM registration surface** mapped (via direct `reg query` on a live install): 3 CLSIDs + AppID + TypeLib + 2 ProgIDs + 10 shellex handler subkeys + `ShellIconOverlayIdentifiers` entry + `Shell Extensions\Approved` value. Hardcoded list + dynamic .NET `Microsoft.Win32.Registry` walk as backup (the cmdlet-based walk took 25+ minutes on real devices and timed out under Intune).
- **MSIX/AppX handling**. AI Now ships `AINowContextWIN11` as a Win11 context-menu MSIX package — `Remove-AppxPackage` handles the main package but leaves orphaned per-user repository stubs at `HKU\<sid>\Software\Classes\Local Settings\...\AppModel\Repository`, which this PR scrubs across every user SID plus the HKLM `AppxAllUserStore` mirrors.
- **Service disable-before-stop** (`sc config disabled` → `Stop-Service` → `WaitForStatus('Stopped', 30s)` → `sc delete`) to prevent auto-restart races.
- **Wildcard match for the uninstall DisplayName** — the existing `^Lenovo AI Now\b` regex silently failed on the actual `Lenovo AI Now 1.3` entry, so the uninstall registry key survived every cycle.
- **`-LiteralPath` for registry paths containing literal `*`** — the existing `-Path` treated `*` as a wildcard and expanded across every HKCR subkey, causing multi-minute hangs in the shellex handler loops.
- **Removed dead code** (`Invoke-Uninstaller`, `Invoke-MsiUninstall`) and the robocopy `/MIR` fallback (could deadlock against kernel-locked DLLs).
- **Sentinel-based loop suppression** in detect so PFRO entries don't bloat between Phase A and reboot.

## How it was validated

End-to-end on two real Lenovo devices:

- Device 1 (fresh-install state, 270 files + locked DLLs): exercised the full PFRO + reboot path. Phase A queued files and wrote the sentinel, user rebooted, install dir cleared, Phase B exited 0.
- Device 2 (mid-cleanup state from previous failed runs): exercised direct deletion after natural reboot. Cleaned up successfully in 28 seconds.

Plus MDE Advanced Hunting across a 36-device fleet to confirm the scope of DLL loading (18 different processes load `OverlayIcon.dll`, 5 load `AINppShell.dll`).

## Caveats

- Tested only against Lenovo AI Now 1.3. Future versions with different CLSID GUIDs would still be caught by the dynamic walk (matched by DLL filename + parent path containing `\Lenovo\Lenovo AI`), but truly new DLL filenames would need the `$lenovoAIDllFileNames` list extended.
- Doesn't handle Lenovo Vantage / Commercial Vantage re-pushing AI Now after removal (out of scope; needs a Vantage policy change).
- Sibling Lenovo AI-family products (AI Solution, AI Meeting Manager) explicitly out of scope.

## Test plan

- [x] Detect on a clean Win11 box (no AI Now) → exit 0
- [x] Detect on a box with AI Now installed → exit 1, all components surfaced in stdout
- [x] Remediate on a fresh AI Now install → exit 3010, PFRO populated, sentinel written
- [x] Reboot validates SMSS clears install dir
- [x] Re-run detect after reboot → exit 0
- [x] Remediate on a mid-cleanup device → exit 0 directly
- [x] Sentinel suppression — second detect during pending-reboot window exits 0
- [x] Multi-user machine (defaultuser0 + a real user) cleans both profiles
- [ ] Confirm against Lenovo AI Now versions other than 1.3 (only 1.3 available for testing)

🤖 Discovery and authoring assisted with Claude Code.
